### PR TITLE
[Feature] Customer 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -47,8 +47,14 @@ public class MemberService {
 
     public void changeCustomerRoleToOwner() {
         Member member = getMember();
-        assertMemberIsNotOwner(member);
+        assertMemberIsNotAlreadyOwner(member);
         member.grantOwner();
+    }
+
+    public void withdrawCustomer() {
+        Member member = getMember();
+        assertMemberIsNotOwner(member);
+        clientRepository.delete(member);
     }
 
     // 검증 로직
@@ -77,12 +83,17 @@ public class MemberService {
 
     private Member getMember() {
         return clientRepository
-                .findByMemberId(0L)
+                .findByMemberId(1L)
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
     } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
 
-    private void assertMemberIsNotOwner(Member member) {
+    private void assertMemberIsNotAlreadyOwner(Member member) {
         if (member.getRole().equals(Role.OWNER))
             throw new CommonException(MemberErrorCode.ROLE_ALREADY_GRANTED);
+    }
+
+    private void assertMemberIsNotOwner(Member member) {
+        if (member.getRole().equals(Role.OWNER))
+            throw new CommonException(MemberErrorCode.OWNER_CANNOT_WITHDRAW);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -77,7 +77,7 @@ public class MemberService {
 
     private Member getMember() {
         return clientRepository
-                .findById(0L)
+                .findByMemberId(0L)
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
     } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
 

--- a/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
@@ -2,6 +2,7 @@ package com.irum.come2us.domain.member.domain.entity;
 
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
 import com.irum.come2us.global.constants.RegexConstants;
+import com.irum.come2us.global.domain.BaseEntity;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import jakarta.persistence.*;
@@ -10,16 +11,20 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @Table(name = "p_member")
+@SQLDelete(sql = "UPDATE p_member SET deleted_at = NOW() WHERE member_id = ?")
+@Where(clause = "deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long memberId;
 
     @Column(name = "email", nullable = false)
     private String email;

--- a/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findById(Long id);
+    Optional<Member> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/irum/come2us/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/irum/come2us/domain/member/presentation/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
     public ResponseEntity<Void> updateMemberInfo(@RequestBody MemberInfoUpdateRequest request) {
         log.info("멤버 개인정보 수정 요청: {}", request);
         memberService.changeMemberNameAndContact(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/password")
@@ -43,12 +43,18 @@ public class MemberController {
             @RequestBody MemberPasswordUpdateRequest request) {
         log.info("멤버 비밀번호 변경 요청: {}", request);
         memberService.changeMemberPassword(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/role")
-    public ResponseEntity<Void> updateMemberRole() {
+    public ResponseEntity<Void> updateCustomerToOwner() {
         memberService.changeCustomerRoleToOwner();
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteCustomer() {
+        memberService.withdrawCustomer();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/MemberErrorCode.java
@@ -14,7 +14,8 @@ public enum MemberErrorCode implements BaseErrorCode {
     INVALID_CONTACT(HttpStatus.BAD_REQUEST, "유효하지 않은 연락처 형식입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "유효한 비밀번호가 아닙니다."),
     DUPLICATED_PASSWORD(HttpStatus.CONFLICT, "변경되는 비밀번호는 기존 비밀번호와 동일할 수 없습니다."),
-    ROLE_ALREADY_GRANTED(HttpStatus.CONFLICT, "중복된 역할을 부여할 수 없습니다.");
+    ROLE_ALREADY_GRANTED(HttpStatus.CONFLICT, "중복된 역할을 부여할 수 없습니다."),
+    OWNER_CANNOT_WITHDRAW(HttpStatus.FORBIDDEN, "판매자 권한 멤버는 계정 삭제가 불가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🛠️ Issue Number
### Closes #24 

📌 **작업 내용 및 특이사항**

- @SQLDelete 기반 Soft Delete 구현
- WHERE 쿼리 조건으로 DB 레벨에서 삭제 처리된 데이터 조회 불가능하도록 구현
- 판매자(Owner) 권한 멤버는 탈퇴 불가능하도록 처리

📚 **참고사항**
- BaseEntity 상속했으나 현재 JpaAudit 미구현 관계로 created_at, created_by 등 주석 처리 후 API 테스트 필요
- 아래 캡쳐와 같이, 소프트 딜리트를 적용해도 이전과 동일한 이메일로 계정 생성하는 것이 가능함. 추후 로그 관련 기능 구현 시 참고
<img width="1238" height="409" alt="image" src="https://github.com/user-attachments/assets/59769fe0-f15d-455d-a477-faffa74a2689" />
