### PR TITLE
[Feature] Member 정보 단일 조회 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -6,6 +6,7 @@ import com.irum.come2us.domain.member.domain.repository.ClientRepository;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import jakarta.transaction.Transactional;
@@ -31,6 +32,11 @@ public class MemberService {
         clientRepository.save(
                 Member.createOwner(
                         request.email(), request.password(), request.name(), request.contact()));
+    }
+
+    public MemberInfoResponse findMemberInfo() {
+        Member member = getMember();
+        return MemberInfoResponse.createMemberInfoResponse(member);
     }
 
     public void changeMemberNameAndContact(MemberInfoUpdateRequest request) {

--- a/src/main/java/com/irum/come2us/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/irum/come2us/domain/member/presentation/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.member.application.service.MemberService;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,11 @@ public class MemberController {
         log.info("판매자 회원가입 요청: {}", request);
         memberService.createOwner(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/info")
+    public MemberInfoResponse getMemberInfo() {
+        return memberService.findMemberInfo();
     }
 
     @PatchMapping("/info")

--- a/src/main/java/com/irum/come2us/domain/member/presentation/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/irum/come2us/domain/member/presentation/dto/response/MemberInfoResponse.java
@@ -1,0 +1,16 @@
+package com.irum.come2us.domain.member.presentation.dto.response;
+
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+
+public record MemberInfoResponse(
+        Long memberId, String email, String name, String contact, Role role) {
+    public static MemberInfoResponse createMemberInfoResponse(Member member) {
+        return new MemberInfoResponse(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getName(),
+                member.getContact(),
+                member.getRole());
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### Closes #26 

📌 **작업 내용 및 특이사항**
- member 정보(아이디, 이메일, 이름, 연락처, 권한) 단일 조회 구현
- List 조회는 현재 MVP에서 쓰임 없기 때문에 보류


📚 **참고사항**
