### PR TITLE
Feature/#25 member manager crud

### DIFF
--- a/src/main/java/com/irum/come2us/domain/member/application/service/ManagerService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/ManagerService.java
@@ -1,0 +1,76 @@
+package com.irum.come2us.domain.member.application.service;
+
+import com.irum.come2us.domain.member.application.util.MemberValidator;
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoListResponse;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManagerService {
+    private final MemberRepository memberRepository;
+    private final MemberValidator memberValidator;
+
+    public void createManager(MemberCreateRequest request) {
+        memberValidator.assertEmailIsNotTaken(request.email());
+        memberRepository.save(
+                Member.createManager(
+                        request.email(), request.password(), request.name(), request.contact()));
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse findManagerInfo(Long memberId) {
+        Member member = memberValidator.getMemberById(memberId);
+        return MemberInfoResponse.createMemberInfoResponse(member);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoListResponse findManagerInfoList(Long lastMemberId, int pageSize) {
+        Member member = memberValidator.getCurrentMember();
+        int limit = pageSize + 1;
+        List<MemberInfoResponse> memberInfoList =
+                memberRepository.findMembersByCursor(lastMemberId, limit);
+        boolean hasNext = memberInfoList.size() > pageSize;
+        Long nextCursor = null;
+        List<MemberInfoResponse> responseList = memberInfoList;
+        if (hasNext) {
+            responseList = memberInfoList.subList(0, pageSize);
+            nextCursor = responseList.get(pageSize - 1).memberId();
+        }
+
+        return new MemberInfoListResponse(responseList, nextCursor, hasNext);
+    }
+
+    public void changeManagerNameAndContact(Long memberId, MemberInfoUpdateRequest request) {
+        Member member = memberValidator.getMemberById(memberId);
+        member.updateName(request.name());
+        member.updateContact(request.contact());
+    }
+
+    public void changeManagerPassword(Long memberId, MemberPasswordUpdateRequest request) {
+        Member member = memberValidator.getMemberById(memberId);
+        memberValidator.validatePassword(request.originalPassword(), request.newPassword(), member);
+        member.updatePassword(request.newPassword());
+    } // 추후 BCryptEncoder 사용한 암/복호화 검증 로직 적용 예정
+
+    public void changeManagerRoleToMaster(Long memberId) {
+        Member member = memberValidator.getMemberById(memberId);
+        memberValidator.assertMemberIsNotOwner(member);
+        member.grantOwner();
+    }
+
+    public void removeManager(Long memberId) {
+        Member member = memberValidator.getMemberById(memberId);
+        memberValidator.assertMemberIsCustomer(member);
+        memberRepository.delete(member);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -1,15 +1,12 @@
 package com.irum.come2us.domain.member.application.service;
 
+import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
-import com.irum.come2us.domain.member.domain.entity.enums.Role;
-import com.irum.come2us.domain.member.domain.repository.ClientRepository;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
-import com.irum.come2us.global.presentation.advice.exception.CommonException;
-import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,89 +15,50 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class MemberService {
-    private final ClientRepository clientRepository;
+    private final MemberRepository memberRepository;
+    private final MemberValidator memberValidator;
 
     public void createCustomer(MemberCreateRequest request) {
-        assertEmailIsNotTaken(request.email());
-        clientRepository.save(
+        memberValidator.assertEmailIsNotTaken(request.email());
+        memberRepository.save(
                 Member.createCustomer(
                         request.email(), request.password(), request.name(), request.contact()));
     }
 
     public void createOwner(MemberCreateRequest request) {
-        validateNewOwnerRegistration(request.email());
-        clientRepository.save(
+        memberValidator.validateNewOwnerRegistration(request.email());
+        memberRepository.save(
                 Member.createOwner(
                         request.email(), request.password(), request.name(), request.contact()));
     }
 
     @Transactional(readOnly = true)
     public MemberInfoResponse findMemberInfo() {
-        Member member = getMember();
+        Member member = memberValidator.getCurrentMember();
         return MemberInfoResponse.createMemberInfoResponse(member);
     }
 
     public void changeMemberNameAndContact(MemberInfoUpdateRequest request) {
-        Member member = getMember();
+        Member member = memberValidator.getCurrentMember();
         member.updateName(request.name());
         member.updateContact(request.contact());
     }
 
     public void changeMemberPassword(MemberPasswordUpdateRequest request) {
-        Member member = getMember();
-        validatePassword(request.originalPassword(), request.newPassword(), member);
+        Member member = memberValidator.getCurrentMember();
+        memberValidator.validatePassword(request.originalPassword(), request.newPassword(), member);
         member.updatePassword(request.newPassword());
     } // 추후 BCryptEncoder 사용한 암/복호화 검증 로직 적용 예정
 
     public void changeCustomerRoleToOwner() {
-        Member member = getMember();
-        assertMemberIsNotAlreadyOwner(member);
+        Member member = memberValidator.getCurrentMember();
+        memberValidator.assertMemberIsNotOwner(member);
         member.grantOwner();
     }
 
     public void withdrawCustomer() {
-        Member member = getMember();
-        assertMemberIsNotOwner(member);
-        clientRepository.delete(member);
-    }
-
-    // 검증 로직
-    private void assertEmailIsNotTaken(String email) {
-        if (clientRepository.findByEmail(email).isPresent())
-            throw new CommonException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
-    }
-
-    private void validateNewOwnerRegistration(String email) {
-        Optional<Member> member = clientRepository.findByEmail(email);
-        if (member.isPresent()) {
-            Role role = member.get().getRole();
-            switch (role) {
-                case OWNER -> throw new CommonException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
-                case CUSTOMER -> throw new CommonException(MemberErrorCode.OWNER_UPGRADE_REQUIRED);
-            }
-        }
-    }
-
-    private void validatePassword(String originalPassword, String newPassword, Member member) {
-        if (member.getPassword().equals(originalPassword))
-            throw new CommonException(MemberErrorCode.INVALID_PASSWORD);
-        if (member.getPassword().equals(newPassword))
-            throw new CommonException(MemberErrorCode.DUPLICATED_PASSWORD);
-    }
-
-    private Member getMember() {
-        return clientRepository
-                .findByMemberId(1L)
-                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-    } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
-
-    private void assertMemberIsNotAlreadyOwner(Member member) {
-        if (member.getRole().equals(Role.OWNER))
-            throw new CommonException(MemberErrorCode.ROLE_ALREADY_GRANTED);
-    }
-
-    private void assertMemberIsNotOwner(Member member) {
-        if (member.getRole().equals(Role.OWNER))
-            throw new CommonException(MemberErrorCode.OWNER_CANNOT_WITHDRAW);
+        Member member = memberValidator.getCurrentMember();
+        memberValidator.assertMemberIsCustomer(member);
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -9,10 +9,10 @@ import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpd
 import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
-import jakarta.transaction.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -34,6 +34,7 @@ public class MemberService {
                         request.email(), request.password(), request.name(), request.contact()));
     }
 
+    @Transactional(readOnly = true)
     public MemberInfoResponse findMemberInfo() {
         Member member = getMember();
         return MemberInfoResponse.createMemberInfoResponse(member);

--- a/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
@@ -1,0 +1,66 @@
+package com.irum.come2us.domain.member.application.util;
+
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberValidator {
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findByMemberId(1L)
+                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+    } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository
+                .findByMemberId(memberId)
+                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+    } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
+
+    public void validatePassword(String originalPassword, String newPassword, Member member) {
+        if (member.getPassword().equals(originalPassword))
+            throw new CommonException(MemberErrorCode.INVALID_PASSWORD);
+        if (member.getPassword().equals(newPassword))
+            throw new CommonException(MemberErrorCode.DUPLICATED_PASSWORD);
+    }
+
+    public void validateNewOwnerRegistration(String email) {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if (member.isPresent()) {
+            Role role = member.get().getRole();
+            switch (role) {
+                case OWNER -> throw new CommonException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+                case CUSTOMER -> throw new CommonException(MemberErrorCode.OWNER_UPGRADE_REQUIRED);
+            }
+        }
+    }
+
+    public void assertMemberIsNotOwner(Member member) {
+        if (member.getRole().equals(Role.OWNER))
+            throw new CommonException(MemberErrorCode.ROLE_ALREADY_GRANTED);
+    }
+
+    public void assertEmailIsNotTaken(String email) {
+        if (memberRepository.findByEmail(email).isPresent())
+            throw new CommonException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+    }
+
+    public void assertMemberIsCustomer(Member member) {
+        Role role = member.getRole();
+        if (!role.equals(Role.CUSTOMER)) {
+            switch (role) {
+                case OWNER -> throw new CommonException(MemberErrorCode.OWNER_CANNOT_WITHDRAW);
+                case MANAGER -> throw new CommonException(MemberErrorCode.MANAGER_CANNOT_WITHDRAW);
+            }
+        }
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/member/domain/repository/ClientRepository.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/repository/ClientRepository.java
@@ -1,6 +1,0 @@
-package com.irum.come2us.domain.member.domain.repository;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ClientRepository extends MemberRepository {}

--- a/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByMemberId(Long memberId);

--- a/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.member.domain.repository;
+
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+    List<MemberInfoResponse> findMembersByCursor(Long lastMemberId, int pageSize);
+}

--- a/src/main/java/com/irum/come2us/domain/member/infrastructure/repository/.gitkeep
+++ b/src/main/java/com/irum/come2us/domain/member/infrastructure/repository/.gitkeep
@@ -1,2 +1,0 @@
-#실제 구현 클래스 작성
-#MemberRepositoryImpl.class

--- a/src/main/java/com/irum/come2us/domain/member/infrastructure/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/member/infrastructure/repository/MemberRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.irum.come2us.domain.member.infrastructure.repository;
+
+import static com.irum.come2us.domain.member.domain.entity.QMember.member;
+
+import com.irum.come2us.domain.member.domain.repository.MemberRepositoryCustom;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MemberInfoResponse> findMembersByCursor(Long lastMemberId, int pageSize) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                MemberInfoResponse.class,
+                                member.memberId,
+                                member.email,
+                                member.name,
+                                member.contact,
+                                member.role))
+                .from(member)
+                .where(cursorCondition(lastMemberId))
+                .orderBy(member.memberId.asc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(Long lastMemberId) {
+        return lastMemberId == null ? null : member.memberId.gt(lastMemberId);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/member/presentation/controller/ManagerController.java
+++ b/src/main/java/com/irum/come2us/domain/member/presentation/controller/ManagerController.java
@@ -1,0 +1,62 @@
+package com.irum.come2us.domain.member.presentation.controller;
+
+import com.irum.come2us.domain.member.application.service.ManagerService;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoListResponse;
+import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/managers")
+@RequiredArgsConstructor
+@Slf4j
+public class ManagerController {
+    private final ManagerService managerService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> createManagerAccount(@RequestBody MemberCreateRequest request) {
+        log.info("매니저 계정 생성 요청: {}", request);
+        managerService.createManager(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/info")
+    public MemberInfoResponse getManagerInfo(@RequestParam Long managerId) {
+        return managerService.findManagerInfo(managerId);
+    }
+
+    @GetMapping
+    public MemberInfoListResponse getManagerInfoList(
+            @RequestParam(name = "lastId", required = false) Long lastMemberId,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize) {
+        return managerService.findManagerInfoList(lastMemberId, pageSize);
+    }
+
+    @PatchMapping("/info")
+    public ResponseEntity<Void> updateManagerInfo(
+            @RequestParam Long managerId, @RequestBody MemberInfoUpdateRequest request) {
+        log.info("매니저 개인정보 수정 요청: {}", request);
+        managerService.changeManagerNameAndContact(managerId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updateManagerPassword(
+            @RequestParam Long managerId, @RequestBody MemberPasswordUpdateRequest request) {
+        log.info("매니저 비밀번호 변경 요청: {}", request);
+        managerService.changeManagerPassword(managerId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteManager(@RequestParam Long managerId) {
+        managerService.removeManager(managerId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/member/presentation/dto/response/MemberInfoListResponse.java
+++ b/src/main/java/com/irum/come2us/domain/member/presentation/dto/response/MemberInfoListResponse.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.domain.member.presentation.dto.response;
+
+import java.util.List;
+
+public record MemberInfoListResponse(
+        List<MemberInfoResponse> memberInfoList, Long nextCursor, boolean hasNext) {}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/MemberErrorCode.java
@@ -15,7 +15,8 @@ public enum MemberErrorCode implements BaseErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "유효한 비밀번호가 아닙니다."),
     DUPLICATED_PASSWORD(HttpStatus.CONFLICT, "변경되는 비밀번호는 기존 비밀번호와 동일할 수 없습니다."),
     ROLE_ALREADY_GRANTED(HttpStatus.CONFLICT, "중복된 역할을 부여할 수 없습니다."),
-    OWNER_CANNOT_WITHDRAW(HttpStatus.FORBIDDEN, "판매자 권한 멤버는 계정 삭제가 불가능합니다.");
+    OWNER_CANNOT_WITHDRAW(HttpStatus.FORBIDDEN, "판매자 권한 멤버는 계정을 삭제할 수 없습니다."),
+    MANAGER_CANNOT_WITHDRAW(HttpStatus.FORBIDDEN, "관리자 권한 멤버는 마스터 권한 없이 계정을 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #25

📌 **작업 내용 및 특이사항**
- Member 유효성 검증 로직 분리한 MemberValidator 클래스 구현
- Master권한 통한 Manager 권한 member 생성/수정/조회/삭제하는 ManagerService 및 API, Repository 메서드 구현
- QueryDSL 기반 cursor 기반 목록 조회 구현


📚 **참고사항**
- 기존 Customer/Owner 대상으로 분리하려 했던 ClientRepository를 MemberRepository로 통폐합
- QueryDSL 기반 로직 작성 위한 MemberRepositoryCustom 인터페이스 및 구현체 작성
