### PR TITLE
[Feature] 상품 수정 로직 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,14 +3,20 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ProductService {
     private final ProductRepository productRepository;
 
@@ -25,5 +31,63 @@ public class ProductService {
                         request.isPublic());
 
         return ProductResponse.from(productRepository.save(product));
+    }
+
+    public ProductResponse updateProduct(UUID productId, ProductUpdateRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (request.name() == null
+                && request.description() == null
+                && request.detailDescription() == null
+                && request.price() == null
+                && request.isPublic() == null) {
+            log.warn("상품 수정 실패: 변경된 필드가 없습니다. productId={}", productId);
+            throw new CommonException(ProductErrorCode.PRODUCT_NOT_MODIFIED);
+        }
+
+        String updatedName = request.name() != null ? request.name() : product.getName();
+        String updatedDescription =
+                request.description() != null ? request.description() : product.getDescription();
+        String updatedDetailDescription =
+                request.detailDescription() != null
+                        ? request.detailDescription()
+                        : product.getDetailDescription();
+        int updatedPrice = request.price() != null ? request.price() : product.getPrice();
+        boolean updatedIsPublic =
+                request.isPublic() != null ? request.isPublic() : product.isPublic();
+
+        log.info("상품 수정 시작: productId={}", productId);
+
+        if (!product.getName().equals(updatedName)) {
+            log.info("상품명 변경: {} → {}", product.getName(), updatedName);
+        }
+        if (!product.getDescription().equals(updatedDescription)) {
+            log.info("상품 설명 변경: {} → {}", product.getDescription(), updatedDescription);
+        }
+        if (!product.getDetailDescription().equals(updatedDetailDescription)) {
+            log.info(
+                    "상품 상세설명 변경: {} → {}",
+                    product.getDetailDescription(),
+                    updatedDetailDescription);
+        }
+        if (product.getPrice() != updatedPrice) {
+            log.info("상품 가격 변경: {} → {}", product.getPrice(), updatedPrice);
+        }
+        if (product.isPublic() != updatedIsPublic) {
+            log.info("공개여부 변경: {} → {}", product.isPublic(), updatedIsPublic);
+        }
+
+        product.updateProduct(
+                updatedName,
+                updatedDescription,
+                updatedDetailDescription,
+                updatedPrice,
+                updatedIsPublic);
+
+        log.info("상품 수정 완료: productId={}", productId);
+        return ProductResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -2,16 +2,15 @@ package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/products")
@@ -26,6 +25,16 @@ public class ProductController {
         log.info("상품 등록 요청: {}", request);
         ProductResponse response = productService.createProduct(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+        // TODO: Security 적용
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ProductResponse> updateProduct(
+            @PathVariable UUID productId, @RequestBody ProductUpdateRequest request) {
+        log.info("상품 정보 수정 요청: productId={}, request={}", productId, request);
+        ProductResponse response = productService.updateProduct(productId, request);
+        return ResponseEntity.ok(response);
 
         // TODO: Security 적용
     }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+public record ProductUpdateRequest(
+        String name,
+        String description,
+        String detailDescription,
+        Boolean isPublic,
+        Integer price) {}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
@@ -1,0 +1,21 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProductErrorCode implements BaseErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
+    PRODUCT_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "상품 수정에 대한 변경된 내용이 없습니다."),
+    PRODUCT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 상품입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #40 

📌 **작업 내용 및 특이사항**
- 상품 등록 API 구현 (`PATCH /products/{productId}`)
- ProductUpdateRequest DTO 정의
- ProductResponse DTO 재사용
- 예외 처리 로직 추가
  - 수정 대상 상품 미존재 -> 404, 미존재 상품 오류
  - 모든 수정 필드가 null인 경우 -> 400, 변경 없음 오류
- 업데이트 시 변경된 필드만 로그로 출력
  - 변경 전/후 값 비교 후 필드별로 로그 출력 (예: `상품명 변경: 무지 반팔 티 → 무지 반팔 티셔츠`)
  - 상품 수정 시작/완료 시점 로깅 추가

📚 **참고사항**
- 추후 Store / Category 매핑 추가 예정
  - 동일 상점 내 상품명 중복 검증 로직(409, PRODUCT_ALREADY_EXISTS 예정)