### PR TITLE
[Feature] 상품 공개 상태 수정 로직 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
@@ -88,6 +89,33 @@ public class ProductService {
                 updatedIsPublic);
 
         log.info("상품 수정 완료: productId={}", productId);
+        return ProductResponse.from(product);
+    }
+
+    public ProductResponse updateProductPublicStatus(
+            UUID productId, ProductPublicUpdateRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        boolean newStatus = request.isPublic();
+        boolean currentStatus = product.isPublic();
+
+        if (newStatus == currentStatus) {
+            log.warn("상품 공개 상태 변경 실패: 동일한 상태 요청 productId={}, isPublic={}", productId, newStatus);
+            throw new CommonException(ProductErrorCode.PRODUCT_NOT_MODIFIED);
+        }
+
+        log.info("상품 공개 상태 변경: productId={}, {} -> {}", productId, currentStatus, newStatus);
+
+        product.updateProduct(
+                product.getName(),
+                product.getDescription(),
+                product.getDetailDescription(),
+                product.getPrice(),
+                newStatus);
+
         return ProductResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
@@ -37,5 +38,13 @@ public class ProductController {
         return ResponseEntity.ok(response);
 
         // TODO: Security 적용
+    }
+
+    @PatchMapping("/{productId}/public")
+    public ResponseEntity<ProductResponse> updateProductPublicStatus(
+            @PathVariable UUID productId, @Valid @RequestBody ProductPublicUpdateRequest request) {
+        log.info("상품 공개 상태 변경 요청: productId={}, isPublic={}", productId, request.isPublic());
+        ProductResponse response = productService.updateProductPublicStatus(productId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductPublicUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductPublicUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ProductPublicUpdateRequest(
+        @NotNull(message = "상품 공개 여부는 필수 입력값입니다.") Boolean isPublic) {}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #41 

📌 **작업 내용 및 특이사항**
- 상품 공개 상태 변경 API 추가 (`PATCH /products/{productId}/public`)
- 단일 필드 전용 DTO `ProductPublicUpdateRequest` 생성  
- 요청된 공개 상태와 기존 상태가 동일할 경우 예외 처리  
  - 동일 상태 요청 시 → 400, 변경 없음 오류
  - 존재하지 않는 상품 요청 시 → 404, 미존재 상품 오류
- 변경 로그 추가 (`이전 상태 → 변경 상태`)


📚 **참고사항**
- 추후 `Store` 매핑 완료 후, 상점주(OWNER) 권한만 수정 가능하도록 변경 예정