### PR TITLE
[Feature] 상품 단일 상세/목록 조회 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -5,6 +5,7 @@ import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
@@ -129,5 +130,14 @@ public class ProductService {
         List<ProductResponse> products = productRepository.findProductsByCursor(cursor, size);
         log.info("상품 목록 조회 완료: cursor={}, size={}, count={}", cursor, size, products.size());
         return products;
+    }
+
+    public ProductDetailResponse getProductById(UUID productId) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        return ProductDetailResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -9,6 +9,7 @@ import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -117,5 +118,16 @@ public class ProductService {
                 newStatus);
 
         return ProductResponse.from(product);
+    }
+
+    public List<ProductResponse> getProductList(UUID cursor, Integer size) {
+        if (size == null || (size != 10 && size != 30 && size != 50)) {
+            log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
+            size = 10;
+        }
+
+        List<ProductResponse> products = productRepository.findProductsByCursor(cursor, size);
+        log.info("상품 목록 조회 완료: cursor={}, size={}, count={}", cursor, size, products.size());
+        return products;
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
@@ -4,4 +4,4 @@ import com.irum.come2us.domain.product.domain.entity.Product;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, UUID> {}
+public interface ProductRepository extends JpaRepository<Product, UUID>, ProductRepositoryCustom {}

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.product.domain.repository;
+
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import java.util.List;
+import java.util.UUID;
+
+public interface ProductRepositoryCustom {
+    List<ProductResponse> findProductsByCursor(UUID cursor, int size);
+}

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.irum.come2us.domain.product.infrastructure.repository;
+
+import com.irum.come2us.domain.product.domain.entity.QProduct;
+import com.irum.come2us.domain.product.domain.repository.ProductRepositoryCustom;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ProductResponse> findProductsByCursor(UUID cursor, int size) {
+        QProduct product = QProduct.product;
+
+        var query =
+                queryFactory
+                        .selectFrom(product)
+                        .where(product.isPublic.isTrue())
+                        .orderBy(product.id.desc()) // Auditing 추가 후, createdAt 기반 생성일자 정렬
+                        .limit(size);
+        if (cursor != null) {
+            query.where(product.id.lt(cursor));
+        }
+
+        return query.fetch().stream().map(ProductResponse::from).toList();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpd
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,15 @@ public class ProductController {
             @PathVariable UUID productId, @Valid @RequestBody ProductPublicUpdateRequest request) {
         log.info("상품 공개 상태 변경 요청: productId={}, isPublic={}", productId, request.isPublic());
         ProductResponse response = productService.updateProductPublicStatus(productId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductResponse>> getProductList(
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(required = false) Integer size) {
+        log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
+        List<ProductResponse> response = productService.getProductList(cursor, size);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -55,6 +56,14 @@ public class ProductController {
             @RequestParam(required = false) Integer size) {
         log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
         List<ProductResponse> response = productService.getProductList(cursor, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductDetailResponse> getProduct(@PathVariable UUID productId) {
+        log.info("상품 상세 조회 요청: productId={}", productId);
+
+        ProductDetailResponse response = productService.getProductById(productId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
@@ -1,0 +1,43 @@
+package com.irum.come2us.domain.product.presentation.dto.response;
+
+import com.irum.come2us.domain.product.domain.entity.Product;
+import java.util.UUID;
+
+/**
+ * 상품 상세 조회 DTO - 추후 Store, Category, Images, Options 확장 예정
+ *
+ * @param id
+ * @param name
+ * @param description
+ * @param detailDescription
+ * @param price
+ * @param isPublic
+ * @param avgRating
+ * @param reviewCount
+ */
+public record ProductDetailResponse(
+        UUID id,
+        String name,
+        String description,
+        String detailDescription,
+        int price,
+        boolean isPublic,
+        Double avgRating,
+        Integer reviewCount
+        // TODO: StoreInfoResponse store,
+        // TODO: CategoryInfoResponse category,
+        // TODO: List<ImageResponse> images,
+        // TODO: List<OptionGroupResponse> optionGroups
+        ) {
+    public static ProductDetailResponse from(Product product) {
+        return new ProductDetailResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getDetailDescription(),
+                product.getPrice(),
+                product.isPublic(),
+                product.getAvgRating(),
+                product.getReviewCount());
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
@@ -3,13 +3,27 @@ package com.irum.come2us.domain.product.presentation.dto.response;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import java.util.UUID;
 
+/**
+ * ProductResponse - 상품 등록/수정/조회 공용 DTO - 추후 ProductListResponse를 분리할지 고민
+ *
+ * @param id
+ * @param name
+ * @param description
+ * @param detailDescription
+ * @param price
+ * @param isPublic
+ * @param avgRating
+ * @param reviewCount
+ */
 public record ProductResponse(
         UUID id,
         String name,
         String description,
         String detailDescription,
         int price,
-        boolean isPublic) {
+        boolean isPublic,
+        Double avgRating,
+        Integer reviewCount) {
     public static ProductResponse from(Product product) {
         return new ProductResponse(
                 product.getId(),
@@ -17,6 +31,8 @@ public record ProductResponse(
                 product.getDescription(),
                 product.getDetailDescription(),
                 product.getPrice(),
-                product.isPublic());
+                product.isPublic(),
+                product.getAvgRating(),
+                product.getReviewCount());
     }
 }

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.irum.come2us.global.infrastructure.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #42 

## 📌 **작업 내용 및 특이사항**
### 상품 목록 조회 API
- QueryDSL 기반 커서(cursor) 적용
- 공개 상품(`isPublic = true`)만 조회
- 평균 평점, 리뷰 개수 응답 필드 추가
- 요구사항에 따라 허용된 페이지 사이즈 설정: `10`, `30`, `50`
  - 다른 값 요청 시 `10`으로 변경

### 상품 단일 상세 조회 API
- `ProductDetailResponse`로 상세 조회 DTO 분리
- 존재하지 않는 상품 요청 시 `404` 예외 발생

## 📚 **참고사항**
- 추후 Store, Category, Images, Options 등 연관관계 확장 예정
- BaseEntity 상속 추가 후 최신순 정렬 수정