### PR TITLE
[Feature] Redis 기반 JWT 관리/인증 필터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa::jakarta'
     annotationProcessor "com.querydsl:querydsl-apt::jakarta"

--- a/src/main/java/com/irum/come2us/domain/auth/application/service/JwtTokenService.java
+++ b/src/main/java/com/irum/come2us/domain/auth/application/service/JwtTokenService.java
@@ -1,0 +1,90 @@
+package com.irum.come2us.domain.auth.application.service;
+
+import com.irum.come2us.domain.auth.domain.entity.RefreshToken;
+import com.irum.come2us.domain.auth.domain.repository.RefreshTokenRepository;
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.global.security.jwt.JwtUtil;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AccessTokenDto createAccessTokenDto(Long memberId, Role authority) {
+        return jwtUtil.generateAccessTokenDto(memberId, authority);
+    }
+
+    public String createAccessToken(Long memberId, Role authority) {
+        return jwtUtil.generateAccessToken(memberId, authority);
+    }
+
+    public RefreshTokenDto createRefreshTokenDto(Long memberId) {
+        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(refreshTokenDto.refreshTokenValue())
+                        .ttl(refreshTokenDto.ttl())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(token)
+                        .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
+
+        if (refreshTokenDto == null) {
+            return null;
+        }
+
+        Optional<RefreshToken> refreshToken = getRefreshToken(refreshTokenDto.memberId());
+
+        if (refreshToken.isPresent()
+                && refreshTokenDto.refreshTokenValue().equals(refreshToken.get().getToken())) {
+            return refreshTokenDto;
+        }
+
+        return null;
+    }
+
+    private RefreshTokenDto parseRefreshToken(String refreshTokenValue) {
+        try {
+            return jwtUtil.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Optional<RefreshToken> getRefreshToken(Long memberId) {
+        return refreshTokenRepository.findById(memberId);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/com/irum/come2us/domain/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.irum.come2us.domain.auth.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id private Long memberId;
+
+    private String token;
+
+    @TimeToLive private long ttl;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/irum/come2us/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.domain.auth.domain.repository;
+
+import com.irum.come2us.domain.auth.domain.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/AccessTokenDto.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.auth.presentation.dto.request;
+
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+
+public record AccessTokenDto(Long memberId, Role role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, Role role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/RefreshTokenDto.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.domain.auth.presentation.dto.request;
+
+public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+    }
+}

--- a/src/main/java/com/irum/come2us/global/constants/SecurityConstants.java
+++ b/src/main/java/com/irum/come2us/global/constants/SecurityConstants.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.global.constants;
+
+public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "authority";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
@@ -1,6 +1,11 @@
 package com.irum.come2us.global.infrastructure.config.security;
 
+import com.irum.come2us.domain.auth.application.service.JwtTokenService;
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.security.JwtAuthenticationFilter;
+import com.irum.come2us.global.util.CookieUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -10,13 +15,18 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -62,6 +72,19 @@ public class SecurityConfig {
                                 .anyRequest()
                                 .permitAll()); // API 완료 후 허용된 public endpoints 외 모든 경로
         // .authenticated() 옵션으로 변경할 예정
+
+        http.addFilterBefore(
+                jwtAuthenticationFilter(memberRepository, jwtTokenService, cookieUtil),
+                UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            MemberRepository memberRepository,
+            JwtTokenService jwtTokenService,
+            CookieUtil cookieUtil) {
+        return new JwtAuthenticationFilter(memberRepository, jwtTokenService, cookieUtil);
     }
 }

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/JwtProperties.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String accessTokenSecret,
+        String refreshTokenSecret,
+        Long accessTokenExpirationTime,
+        Long refreshTokenExpirationTime,
+        String issuer) {
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/PropertiesConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/PropertiesConfig.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({JwtProperties.class, RedisProperties.class})
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/RedisProperties.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(String host, int port, String password) {}

--- a/src/main/java/com/irum/come2us/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/irum/come2us/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,124 @@
+package com.irum.come2us.global.security;
+
+import static com.irum.come2us.global.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+import static com.irum.come2us.global.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.irum.come2us.domain.auth.application.service.JwtTokenService;
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.util.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+        String refreshTokenCookieValue = extractRefreshTokenFromCookie(request);
+
+        // 헤더에 AT가 있으면 우선적으로 검증
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+            // AT가 유효하면 통과
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.memberId(), accessTokenDto.role());
+
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        // AT가 유효하지 않다면 RT 파싱
+        if (refreshTokenCookieValue != null) {
+            RefreshTokenDto refreshTokenDto =
+                    jwtTokenService.retrieveRefreshToken(refreshTokenCookieValue);
+
+            // RT가 유효하면 AT, RT 재발급
+            if (refreshTokenDto != null) {
+                Member member =
+                        memberRepository
+                                .findById(refreshTokenDto.memberId())
+                                .orElseThrow(
+                                        () ->
+                                                new CommonException(
+                                                        MemberErrorCode.MEMBER_NOT_FOUND));
+
+                AccessTokenDto reissueAccessTokenDto =
+                        jwtTokenService.createAccessTokenDto(
+                                member.getMemberId(), member.getRole());
+                RefreshTokenDto reissueRefreshTokenDto =
+                        jwtTokenService.createRefreshTokenDto(member.getMemberId());
+
+                HttpHeaders headers =
+                        cookieUtil.generateRefreshTokenCookie(
+                                reissueRefreshTokenDto.refreshTokenValue());
+
+                response.addHeader(
+                        HttpHeaders.AUTHORIZATION,
+                        TOKEN_PREFIX + reissueAccessTokenDto.accessTokenValue());
+                response.addHeader(
+                        HttpHeaders.SET_COOKIE, headers.getFirst(HttpHeaders.SET_COOKIE));
+            }
+        }
+
+        // AT, RT가 모두 만료된 경우 실패
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToken(Long memberId, Role authority) {
+        UserDetails userDetails = new MemberDetails(memberId, authority);
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
+
+        if (cookie != null) {
+            return cookie.getValue();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
@@ -1,0 +1,126 @@
+package com.irum.come2us.global.security.jwt;
+
+import static com.irum.come2us.global.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.global.infrastructure.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    public AccessTokenDto generateAccessTokenDto(Long memberId, Role authority) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String accessTokenValue = buildAccessToken(memberId, authority, issuedAt, expiredAt);
+        return AccessTokenDto.of(memberId, authority, accessTokenValue);
+    }
+
+    public String generateAccessToken(Long memberId, Role authority) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, authority, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String refreshTokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return RefreshTokenDto.of(
+                memberId, refreshTokenValue, jwtProperties.refreshTokenExpirationTime());
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    Role.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
+
+            return RefreshTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    refreshTokenValue,
+                    jwtProperties.refreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parser()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.refreshTokenExpirationTime();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+
+    private String buildAccessToken(Long memberId, Role authority, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, authority.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/util/CookieUtil.java
+++ b/src/main/java/com/irum/come2us/global/util/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.irum.come2us.global.util;
+
+import static com.irum.come2us.global.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(determineSameSitePolicy())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    public HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(determineSameSitePolicy())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    private String determineSameSitePolicy() {
+        return Cookie.SameSite.NONE.attributeValue();
+    }
+}

--- a/src/main/resources/application-redis.yaml
+++ b/src/main/resources/application-redis.yaml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -1,0 +1,6 @@
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER:irum}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #61 #63 

📌 **작업 내용 및 특이사항**
- Redis 관련 의존성 추가
- JWT, Redis 프로퍼티 및 config 작성
- AccessToken, RefreshToken 설계 및 생성/파싱 로직 작성
- Cookie 기반 RefreshToken 관리 로직 작성
- JwtAuthenticationFilter 구현 및 필터체인 등록

📚 **참고사항**
- 현재 RT 만료 시 MemberRepostiory를 통해 새롭게 객체를 조회해 아이디와 role을 찾아오도록 구현했습니다. 추후 MSA 구현 시 토큰 인증 로직을 API Gateway 단에 적용하면 게이트웨이가 MemberService, 또는 AuthService 와 강하게 결합할 가능성이 있을 것 같습니다. 이 부분 확인 및 검토 부탁드립니다.

- JWT Secret의 경우 .env 파일 따로 작성해서 관리하고 있습니다. 요청하시면 타 채널 통해 공유드리겠습니다.