### PR TITLE
[Feature] JPA Audit 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
@@ -2,7 +2,7 @@ package com.irum.come2us.domain.member.domain.entity;
 
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
 import com.irum.come2us.global.constants.RegexConstants;
-import com.irum.come2us.global.domain.BaseEntity;
+import com.irum.come2us.global.domain.BaseTimeEntity;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import jakarta.persistence.*;
@@ -20,7 +20,7 @@ import org.hibernate.annotations.Where;
 @SQLDelete(sql = "UPDATE p_member SET deleted_at = NOW() WHERE member_id = ?")
 @Where(clause = "deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity {
+public class Member extends BaseTimeEntity {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/irum/come2us/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/irum/come2us/global/domain/BaseTimeEntity.java
@@ -3,20 +3,23 @@ package com.irum.come2us.global.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @MappedSuperclass
-public class BaseEntity extends BaseTimeEntity {
-    @CreatedBy
+public class BaseTimeEntity {
+    @CreatedDate
     @Column(updatable = false, nullable = false)
-    private Long createdBy;
+    private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
     @Column(nullable = false)
-    private Long updatedBy;
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,15 @@
+package com.irum.come2us.global.infrastructure.config.jpa;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+    @Bean
+    public AuditorAware<Long> auditorProvider() {
+        return new MemberAuditorAware();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/MemberAuditorAware.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/MemberAuditorAware.java
@@ -1,0 +1,28 @@
+package com.irum.come2us.global.infrastructure.config.jpa;
+
+import com.irum.come2us.global.security.MemberDetails;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class MemberAuditorAware implements AuditorAware<Long> {
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || authentication.getPrincipal() == null
+                || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+        if (authentication.getPrincipal() instanceof MemberDetails) {
+            MemberDetails nowMember = (MemberDetails) authentication.getPrincipal();
+            Long memberId = Long.parseLong(nowMember.getUsername());
+            log.info("현재 유저: {}", nowMember.getUsername());
+            return Optional.of(memberId);
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #62 

📌 **작업 내용 및 특이사항**

- JpaAuditingConfig 작성 및 MemberAuditorAware 구현
- BaseEntity & BaseTimeEntity 분리 
- -> Member의 경우 생성 시점에 생성자는 인증된 사용자가 아니며, 생성하는 해당 객체가 사용자 본인을 의미하기 때문 


📚 **참고사항**
