### PR TITLE
[Feature] 상품 검색 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -121,14 +121,23 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
-    public List<ProductResponse> getProductList(UUID cursor, Integer size) {
+    public List<ProductResponse> getProductList(UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
             size = 10;
         }
 
-        List<ProductResponse> products = productRepository.findProductsByCursor(cursor, size);
-        log.info("상품 목록 조회 완료: cursor={}, size={}, count={}", cursor, size, products.size());
+        List<ProductResponse> products;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            log.info("상품 검색 요청: keyword={}, cursor={}, size={}", keyword, cursor, size);
+            products = productRepository.findProductsByKeyword(cursor, size, keyword);
+        } else {
+            log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
+            products = productRepository.findProductsByCursor(cursor, size);
+        }
+
+        log.info("상품 목록 조회 완료: keyword={}, count={}", keyword, products.size());
         return products;
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.UUID;
 
 public interface ProductRepositoryCustom {
     List<ProductResponse> findProductsByCursor(UUID cursor, int size);
+
+    List<ProductResponse> findProductsByKeyword(UUID cursor, int size, String keyword);
 }

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -31,17 +31,23 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     public List<ProductResponse> findProductsByCursor(UUID cursor, int size) {
         QProduct product = QProduct.product;
 
-        var query =
-                queryFactory
-                        .selectFrom(product)
-                        .where(product.isPublic.isTrue())
-                        .orderBy(product.id.desc()) // Auditing 추가 후, createdAt 기반 생성일자 정렬
-                        .limit(size);
-        if (cursor != null) {
-            query.where(product.id.lt(cursor));
-        }
-
-        return query.fetch().stream().map(ProductResponse::from).toList();
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
+                .from(product)
+                .where(product.isPublic.isTrue(), ltCursor(cursor, product))
+                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
+                .limit(size)
+                .fetch();
     }
 
     @Override
@@ -65,7 +71,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.isPublic.isTrue(),
                         ltCursor(cursor, product),
                         containsKeyword(keyword, product))
-                .orderBy(product.id.desc())  // createdAt 기준 정렬로 변경 예정
+                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.irum.come2us.domain.product.infrastructure.repository;
 import com.irum.come2us.domain.product.domain.entity.QProduct;
 import com.irum.come2us.domain.product.domain.repository.ProductRepositoryCustom;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.UUID;
@@ -13,6 +15,17 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+
+    private BooleanExpression ltCursor(UUID cursor, QProduct product) {
+        return cursor != null ? product.id.lt(cursor) : null;
+    }
+
+    private BooleanExpression containsKeyword(String keyword, QProduct product) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return null;
+        }
+        return product.name.containsIgnoreCase(keyword);
+    }
 
     @Override
     public List<ProductResponse> findProductsByCursor(UUID cursor, int size) {
@@ -29,5 +42,31 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         }
 
         return query.fetch().stream().map(ProductResponse::from).toList();
+    }
+
+    @Override
+    public List<ProductResponse> findProductsByKeyword(UUID cursor, int size, String keyword) {
+        QProduct product = QProduct.product;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
+                .from(product)
+                .where(
+                        product.isPublic.isTrue(),
+                        ltCursor(cursor, product),
+                        containsKeyword(keyword, product))
+                .orderBy(product.id.desc())  // createdAt 기준 정렬로 변경 예정
+                .limit(size)
+                .fetch();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -53,9 +53,10 @@ public class ProductController {
     @GetMapping
     public ResponseEntity<List<ProductResponse>> getProductList(
             @RequestParam(required = false) UUID cursor,
-            @RequestParam(required = false) Integer size) {
-        log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
-        List<ProductResponse> response = productService.getProductList(cursor, size);
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) String keyword) {
+        log.info("상품 목록 조회 요청: cursor={}, size={}, keyword={}", cursor, size, keyword);
+        List<ProductResponse> response = productService.getProductList(cursor, size, keyword);
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #44 

📌 **작업 내용 및 특이사항**
- QueryDSL 상품 목록 및 검색 구현
- 기존 상품 목록 검색 Controller에 `@RequestParam` 추가
- 검색어 미입력 시 전체 목록 조회로 처리
- 기본 페이지 사이즈 10

📚 **참고사항**
- BaseEntity 상속 후 생성일자 기준 정렬
- Store, Category 매핑 후 검색 조건 확장 가능성 존재