### PR TITLE
[Feature] Product CRUD 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,14 +3,20 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ProductService {
     private final ProductRepository productRepository;
 
@@ -25,5 +31,63 @@ public class ProductService {
                         request.isPublic());
 
         return ProductResponse.from(productRepository.save(product));
+    }
+
+    public ProductResponse updateProduct(UUID productId, ProductUpdateRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (request.name() == null
+                && request.description() == null
+                && request.detailDescription() == null
+                && request.price() == null
+                && request.isPublic() == null) {
+            log.warn("상품 수정 실패: 변경된 필드가 없습니다. productId={}", productId);
+            throw new CommonException(ProductErrorCode.PRODUCT_NOT_MODIFIED);
+        }
+
+        String updatedName = request.name() != null ? request.name() : product.getName();
+        String updatedDescription =
+                request.description() != null ? request.description() : product.getDescription();
+        String updatedDetailDescription =
+                request.detailDescription() != null
+                        ? request.detailDescription()
+                        : product.getDetailDescription();
+        int updatedPrice = request.price() != null ? request.price() : product.getPrice();
+        boolean updatedIsPublic =
+                request.isPublic() != null ? request.isPublic() : product.isPublic();
+
+        log.info("상품 수정 시작: productId={}", productId);
+
+        if (!product.getName().equals(updatedName)) {
+            log.info("상품명 변경: {} → {}", product.getName(), updatedName);
+        }
+        if (!product.getDescription().equals(updatedDescription)) {
+            log.info("상품 설명 변경: {} → {}", product.getDescription(), updatedDescription);
+        }
+        if (!product.getDetailDescription().equals(updatedDetailDescription)) {
+            log.info(
+                    "상품 상세설명 변경: {} → {}",
+                    product.getDetailDescription(),
+                    updatedDetailDescription);
+        }
+        if (product.getPrice() != updatedPrice) {
+            log.info("상품 가격 변경: {} → {}", product.getPrice(), updatedPrice);
+        }
+        if (product.isPublic() != updatedIsPublic) {
+            log.info("공개여부 변경: {} → {}", product.isPublic(), updatedIsPublic);
+        }
+
+        product.updateProduct(
+                updatedName,
+                updatedDescription,
+                updatedDetailDescription,
+                updatedPrice,
+                updatedIsPublic);
+
+        log.info("상품 수정 완료: productId={}", productId);
+        return ProductResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -5,10 +5,12 @@ import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -117,5 +119,25 @@ public class ProductService {
                 newStatus);
 
         return ProductResponse.from(product);
+    }
+
+    public List<ProductResponse> getProductList(UUID cursor, Integer size) {
+        if (size == null || (size != 10 && size != 30 && size != 50)) {
+            log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
+            size = 10;
+        }
+
+        List<ProductResponse> products = productRepository.findProductsByCursor(cursor, size);
+        log.info("상품 목록 조회 완료: cursor={}, size={}, count={}", cursor, size, products.size());
+        return products;
+    }
+
+    public ProductDetailResponse getProductById(UUID productId) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        return ProductDetailResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
@@ -88,6 +89,33 @@ public class ProductService {
                 updatedIsPublic);
 
         log.info("상품 수정 완료: productId={}", productId);
+        return ProductResponse.from(product);
+    }
+
+    public ProductResponse updateProductPublicStatus(
+            UUID productId, ProductPublicUpdateRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        boolean newStatus = request.isPublic();
+        boolean currentStatus = product.isPublic();
+
+        if (newStatus == currentStatus) {
+            log.warn("상품 공개 상태 변경 실패: 동일한 상태 요청 productId={}, isPublic={}", productId, newStatus);
+            throw new CommonException(ProductErrorCode.PRODUCT_NOT_MODIFIED);
+        }
+
+        log.info("상품 공개 상태 변경: productId={}, {} -> {}", productId, currentStatus, newStatus);
+
+        product.updateProduct(
+                product.getName(),
+                product.getDescription(),
+                product.getDetailDescription(),
+                product.getPrice(),
+                newStatus);
+
         return ProductResponse.from(product);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -1,0 +1,29 @@
+package com.irum.come2us.domain.product.application.service;
+
+import com.irum.come2us.domain.product.domain.entity.Product;
+import com.irum.come2us.domain.product.domain.repository.ProductRepository;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    // TODO: 상점 매핑 시, 같은 상점 내 같은 상품 중복 처리
+    public ProductResponse createProduct(ProductCreateRequest request) {
+        Product product =
+                Product.createProduct(
+                        request.name(),
+                        request.description(),
+                        request.detailDescription(),
+                        request.price(),
+                        request.isPublic());
+
+        return ProductResponse.from(productRepository.save(product));
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -121,14 +121,23 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
-    public List<ProductResponse> getProductList(UUID cursor, Integer size) {
+    public List<ProductResponse> getProductList(UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
             size = 10;
         }
 
-        List<ProductResponse> products = productRepository.findProductsByCursor(cursor, size);
-        log.info("상품 목록 조회 완료: cursor={}, size={}, count={}", cursor, size, products.size());
+        List<ProductResponse> products;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            log.info("상품 검색 요청: keyword={}, cursor={}, size={}", keyword, cursor, size);
+            products = productRepository.findProductsByKeyword(cursor, size, keyword);
+        } else {
+            log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
+            products = productRepository.findProductsByCursor(cursor, size);
+        }
+
+        log.info("상품 목록 조회 완료: keyword={}, count={}", keyword, products.size());
         return products;
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.domain.product.domain.repository;
+
+import com.irum.come2us.domain.product.domain.entity.Product;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, UUID> {}

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepository.java
@@ -4,4 +4,4 @@ import com.irum.come2us.domain.product.domain.entity.Product;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, UUID> {}
+public interface ProductRepository extends JpaRepository<Product, UUID>, ProductRepositoryCustom {}

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.product.domain.repository;
+
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import java.util.List;
+import java.util.UUID;
+
+public interface ProductRepositoryCustom {
+    List<ProductResponse> findProductsByCursor(UUID cursor, int size);
+}

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.UUID;
 
 public interface ProductRepositoryCustom {
     List<ProductResponse> findProductsByCursor(UUID cursor, int size);
+
+    List<ProductResponse> findProductsByKeyword(UUID cursor, int size, String keyword);
 }

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.irum.come2us.domain.product.infrastructure.repository;
+
+import com.irum.come2us.domain.product.domain.entity.QProduct;
+import com.irum.come2us.domain.product.domain.repository.ProductRepositoryCustom;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ProductResponse> findProductsByCursor(UUID cursor, int size) {
+        QProduct product = QProduct.product;
+
+        var query =
+                queryFactory
+                        .selectFrom(product)
+                        .where(product.isPublic.isTrue())
+                        .orderBy(product.id.desc()) // Auditing 추가 후, createdAt 기반 생성일자 정렬
+                        .limit(size);
+        if (cursor != null) {
+            query.where(product.id.lt(cursor));
+        }
+
+        return query.fetch().stream().map(ProductResponse::from).toList();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.irum.come2us.domain.product.infrastructure.repository;
 import com.irum.come2us.domain.product.domain.entity.QProduct;
 import com.irum.come2us.domain.product.domain.repository.ProductRepositoryCustom;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.UUID;
@@ -14,20 +16,63 @@ import org.springframework.stereotype.Repository;
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
+    private BooleanExpression ltCursor(UUID cursor, QProduct product) {
+        return cursor != null ? product.id.lt(cursor) : null;
+    }
+
+    private BooleanExpression containsKeyword(String keyword, QProduct product) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return null;
+        }
+        return product.name.containsIgnoreCase(keyword);
+    }
+
     @Override
     public List<ProductResponse> findProductsByCursor(UUID cursor, int size) {
         QProduct product = QProduct.product;
 
-        var query =
-                queryFactory
-                        .selectFrom(product)
-                        .where(product.isPublic.isTrue())
-                        .orderBy(product.id.desc()) // Auditing 추가 후, createdAt 기반 생성일자 정렬
-                        .limit(size);
-        if (cursor != null) {
-            query.where(product.id.lt(cursor));
-        }
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
+                .from(product)
+                .where(product.isPublic.isTrue(), ltCursor(cursor, product))
+                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
+                .limit(size)
+                .fetch();
+    }
 
-        return query.fetch().stream().map(ProductResponse::from).toList();
+    @Override
+    public List<ProductResponse> findProductsByKeyword(UUID cursor, int size, String keyword) {
+        QProduct product = QProduct.product;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
+                .from(product)
+                .where(
+                        product.isPublic.isTrue(),
+                        ltCursor(cursor, product),
+                        containsKeyword(keyword, product))
+                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
+                .limit(size)
+                .fetch();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -53,9 +53,10 @@ public class ProductController {
     @GetMapping
     public ResponseEntity<List<ProductResponse>> getProductList(
             @RequestParam(required = false) UUID cursor,
-            @RequestParam(required = false) Integer size) {
-        log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
-        List<ProductResponse> response = productService.getProductList(cursor, size);
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) String keyword) {
+        log.info("상품 목록 조회 요청: cursor={}, size={}, keyword={}", cursor, size, keyword);
+        List<ProductResponse> response = productService.getProductList(cursor, size, keyword);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -2,16 +2,15 @@ package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/products")
@@ -26,6 +25,16 @@ public class ProductController {
         log.info("상품 등록 요청: {}", request);
         ProductResponse response = productService.createProduct(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+        // TODO: Security 적용
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ProductResponse> updateProduct(
+            @PathVariable UUID productId, @RequestBody ProductUpdateRequest request) {
+        log.info("상품 정보 수정 요청: productId={}, request={}", productId, request);
+        ProductResponse response = productService.updateProduct(productId, request);
+        return ResponseEntity.ok(response);
 
         // TODO: Security 적용
     }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
@@ -37,5 +38,13 @@ public class ProductController {
         return ResponseEntity.ok(response);
 
         // TODO: Security 적용
+    }
+
+    @PatchMapping("/{productId}/public")
+    public ResponseEntity<ProductResponse> updateProductPublicStatus(
+            @PathVariable UUID productId, @Valid @RequestBody ProductPublicUpdateRequest request) {
+        log.info("상품 공개 상태 변경 요청: productId={}, isPublic={}", productId, request.isPublic());
+        ProductResponse response = productService.updateProductPublicStatus(productId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -4,8 +4,10 @@ import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +47,23 @@ public class ProductController {
             @PathVariable UUID productId, @Valid @RequestBody ProductPublicUpdateRequest request) {
         log.info("상품 공개 상태 변경 요청: productId={}, isPublic={}", productId, request.isPublic());
         ProductResponse response = productService.updateProductPublicStatus(productId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProductResponse>> getProductList(
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(required = false) Integer size) {
+        log.info("상품 목록 조회 요청: cursor={}, size={}", cursor, size);
+        List<ProductResponse> response = productService.getProductList(cursor, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductDetailResponse> getProduct(@PathVariable UUID productId) {
+        log.info("상품 상세 조회 요청: productId={}", productId);
+
+        ProductDetailResponse response = productService.getProductById(productId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -1,0 +1,32 @@
+package com.irum.come2us.domain.product.presentation.controller;
+
+import com.irum.come2us.domain.product.application.service.ProductService;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+@Slf4j
+public class ProductController {
+    private final ProductService productService;
+
+    @PostMapping
+    public ResponseEntity<ProductResponse> createProduct(
+            @Valid @RequestBody ProductCreateRequest request) {
+        log.info("상품 등록 요청: {}", request);
+        ProductResponse response = productService.createProduct(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+        // TODO: Security 적용
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
@@ -1,0 +1,12 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductCreateRequest(
+        @NotBlank(message = "상품명은 필수 입력값입니다.") String name,
+        @NotBlank(message = "상품 설명은 필수 입력값입니다.") String description,
+        @NotBlank(message = "상품 상세 설명은 필수 입력값입니다.") String detailDescription,
+        @NotNull(message = "상품 공개 여부는 필수 입력값입니다.") Boolean isPublic,
+        @Min(value = 0, message = "상품 가격은 0 이상이어야 합니다.") int price) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductPublicUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductPublicUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ProductPublicUpdateRequest(
+        @NotNull(message = "상품 공개 여부는 필수 입력값입니다.") Boolean isPublic) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+public record ProductUpdateRequest(
+        String name,
+        String description,
+        String detailDescription,
+        Boolean isPublic,
+        Integer price) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
@@ -4,7 +4,7 @@ import com.irum.come2us.domain.product.domain.entity.Product;
 import java.util.UUID;
 
 /**
- * ProductResponse - 상품 등록/수정/조회 공용 DTO - 추후 ProductListResponse를 분리할지 고민
+ * 상품 상세 조회 DTO - 추후 Store, Category, Images, Options 확장 예정
  *
  * @param id
  * @param name
@@ -15,7 +15,7 @@ import java.util.UUID;
  * @param avgRating
  * @param reviewCount
  */
-public record ProductResponse(
+public record ProductDetailResponse(
         UUID id,
         String name,
         String description,
@@ -23,9 +23,14 @@ public record ProductResponse(
         int price,
         boolean isPublic,
         Double avgRating,
-        Integer reviewCount) {
-    public static ProductResponse from(Product product) {
-        return new ProductResponse(
+        Integer reviewCount
+        // TODO: StoreInfoResponse store,
+        // TODO: CategoryInfoResponse category,
+        // TODO: List<ImageResponse> images,
+        // TODO: List<OptionGroupResponse> optionGroups
+        ) {
+    public static ProductDetailResponse from(Product product) {
+        return new ProductDetailResponse(
                 product.getId(),
                 product.getName(),
                 product.getDescription(),

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
@@ -1,0 +1,22 @@
+package com.irum.come2us.domain.product.presentation.dto.response;
+
+import com.irum.come2us.domain.product.domain.entity.Product;
+import java.util.UUID;
+
+public record ProductResponse(
+        UUID id,
+        String name,
+        String description,
+        String detailDescription,
+        int price,
+        boolean isPublic) {
+    public static ProductResponse from(Product product) {
+        return new ProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getDetailDescription(),
+                product.getPrice(),
+                product.isPublic());
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
@@ -4,8 +4,6 @@ import com.irum.come2us.domain.product.domain.entity.Product;
 import java.util.UUID;
 
 /**
- * ProductResponse - 상품 등록/수정/조회 공용 DTO - 추후 ProductListResponse를 분리할지 고민
- *
  * @param id
  * @param name
  * @param description

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.irum.come2us.global.infrastructure.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
@@ -1,0 +1,21 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProductErrorCode implements BaseErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
+    PRODUCT_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "상품 수정에 대한 변경된 내용이 없습니다."),
+    PRODUCT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 상품입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #38 

## 📌 **작업 내용 및 특이사항**
### Product Create
- 상품 등록 API (`POST /products`)
- DTO (`ProductCreateRequest`, `ProductResponse`) 정의
- 입력값 검증 (`@NotBlank`, `@Min`) 적용
- **예정**: 상점 내 중복 상품명 예외 처리 

### Product Read
- 상품 목록 조회 API (`GET /products`)
  - QueryDSL 기반 커서 페이징 구현
  - `cursor`, `size`, `keyword` 조합으로 검색 및 목록 조회 가능
  - 허용 size: 10, 30, 50 (기타 값은 10으로 기본 설정)
  - 공개 상품(`isPublic=true`)만 조회
- 상품 상세 조회 API (`GET /products/{productId}`)
  - `ProductDetailResponse` DTO 정의
  - **예정**: Store, Category, Options, Images 등 다른 도메인 개발 후 연결 및 확장

### Product Update
- 상품 정보 수정 API (`PATCH /products/{productId}`)
  - 변경 로그 상세 출력 (`이전 값 -> 변경 값`)
  - 변경 사항이 없을 경우 `ProductErrorCode.PRODUCT_NOT_MODIFIED` 예외 발생
- 상품 공개 상태 변경 API (`PAHTCH /products/{productId}/public`)
  - 공개/비공개 상태를 별도 API로 관리
  - 동일 상태 요청 시 예외 처리 `ProductErrorCode.PRODUCT_NOT_MODIFIED`

### Product Delte
- 삭제 로직은 BaseEntity 적용 후 별도 이슈로 진행 예정

## 📚 **참고사항**
- 권한 관련 작업 추후 진행 예정 (`OWNER`/`MANAGER`만 상품에 대한 등록/수정/삭제 가능)
- Store, Category, Options, Images 등 다른 도메인 개발 후 매핑 예정
- BaseEntity 코드 rebase할 경우 변경 범위가 커져 코드 리뷰에 어려움이 있을 거 같아 삭제 로직 관련 작업 및 생성일자(createdAt) 정렬 작업은 별도 이슈로 진행하겠습니다.

### 🔗관련 PR
#50 #53 #57 #71 #76 