### PR TITLE
[Feature]Spring Security 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,19 +49,28 @@ clean {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // JPA & DB
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
+
+    //Spring Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'com.querydsl:querydsl-jpa::jakarta'
+
+    //Spring Security & JWT
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa::jakarta'
     annotationProcessor "com.querydsl:querydsl-apt::jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'org.postgresql:postgresql'
-    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.querydsl:querydsl-jpa::jakarta'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
     annotationProcessor "com.querydsl:querydsl-apt::jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa::jakarta'
     annotationProcessor "com.querydsl:querydsl-apt::jakarta"

--- a/src/main/java/com/irum/come2us/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/irum/come2us/domain/auth/application/service/AuthService.java
@@ -1,0 +1,38 @@
+package com.irum.come2us.domain.auth.application.service;
+
+import com.irum.come2us.domain.auth.domain.repository.RefreshTokenRepository;
+import com.irum.come2us.domain.auth.presentation.dto.request.MemberLoginRequest;
+import com.irum.come2us.domain.auth.presentation.dto.response.MemberLoginResponse;
+import com.irum.come2us.domain.member.application.util.MemberValidator;
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.global.util.CookieUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberValidator memberValidator;
+    private final JwtTokenService jwtTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final CookieUtil cookieUtil;
+
+    public MemberLoginResponse processMemberLogin(MemberLoginRequest request) {
+        Member member = memberValidator.getMemberByEmail(request.email());
+        memberValidator.assertPassword(request.password(), member);
+        String accessToken =
+                jwtTokenService.createAccessToken(member.getMemberId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getMemberId());
+        return MemberLoginResponse.of(accessToken, refreshToken);
+    }
+
+    public HttpHeaders processMemberLogout() {
+        Member member = memberValidator.getCurrentMember();
+        refreshTokenRepository.deleteById(member.getMemberId());
+        return cookieUtil.deleteRefreshTokenCookie();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/application/service/JwtTokenService.java
+++ b/src/main/java/com/irum/come2us/domain/auth/application/service/JwtTokenService.java
@@ -1,0 +1,90 @@
+package com.irum.come2us.domain.auth.application.service;
+
+import com.irum.come2us.domain.auth.domain.entity.RefreshToken;
+import com.irum.come2us.domain.auth.domain.repository.RefreshTokenRepository;
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.global.security.jwt.JwtUtil;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AccessTokenDto createAccessTokenDto(Long memberId, Role authority) {
+        return jwtUtil.generateAccessTokenDto(memberId, authority);
+    }
+
+    public String createAccessToken(Long memberId, Role authority) {
+        return jwtUtil.generateAccessToken(memberId, authority);
+    }
+
+    public RefreshTokenDto createRefreshTokenDto(Long memberId) {
+        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(refreshTokenDto.refreshTokenValue())
+                        .ttl(refreshTokenDto.ttl())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(token)
+                        .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
+
+        if (refreshTokenDto == null) {
+            return null;
+        }
+
+        Optional<RefreshToken> refreshToken = getRefreshToken(refreshTokenDto.memberId());
+
+        if (refreshToken.isPresent()
+                && refreshTokenDto.refreshTokenValue().equals(refreshToken.get().getToken())) {
+            return refreshTokenDto;
+        }
+
+        return null;
+    }
+
+    private RefreshTokenDto parseRefreshToken(String refreshTokenValue) {
+        try {
+            return jwtUtil.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Optional<RefreshToken> getRefreshToken(Long memberId) {
+        return refreshTokenRepository.findById(memberId);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/domain/entity/BlackListToken.java
+++ b/src/main/java/com/irum/come2us/domain/auth/domain/entity/BlackListToken.java
@@ -1,0 +1,27 @@
+package com.irum.come2us.domain.auth.domain.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash("blacklistToken")
+public class BlackListToken {
+
+    @Id private final String token;
+
+    @TimeToLive private final long ttl;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private BlackListToken(String token, long ttl) {
+        this.token = token;
+        this.ttl = ttl;
+    }
+
+    public static BlackListToken createBlackListToken(String token, Long ttl) {
+        return builder().token(token).ttl(ttl).build();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/com/irum/come2us/domain/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.irum.come2us.domain.auth.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id private Long memberId;
+
+    private String token;
+
+    @TimeToLive private long ttl;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/irum/come2us/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.domain.auth.domain.repository;
+
+import com.irum.come2us.domain.auth.domain.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.irum.come2us.domain.auth.presentation.controller;
+
+import com.irum.come2us.domain.auth.application.service.AuthService;
+import com.irum.come2us.domain.auth.presentation.dto.request.MemberLoginRequest;
+import com.irum.come2us.domain.auth.presentation.dto.response.MemberLoginResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public MemberLoginResponse login(@RequestBody MemberLoginRequest request) {
+        log.info("회원 로그인 요청: {}", request);
+        return authService.processMemberLogin(request);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        HttpHeaders headers = authService.processMemberLogout();
+        response.addHeader(HttpHeaders.SET_COOKIE, headers.getFirst(HttpHeaders.SET_COOKIE));
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/AccessTokenDto.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.auth.presentation.dto.request;
+
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+
+public record AccessTokenDto(Long memberId, Role role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, Role role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/MemberLoginRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+        @NotBlank(message = "이메일은 필수 입력값입니다.") @Email(message = "이메일 형식에 맞지 않습니다.") String email,
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.") String password) {}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/RefreshTokenDto.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/request/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.domain.auth.presentation.dto.request;
+
+public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/auth/presentation/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/irum/come2us/domain/auth/presentation/dto/response/MemberLoginResponse.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.auth.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record MemberLoginResponse(String accessToken, @JsonIgnore String refreshToken) {
+    public static MemberLoginResponse of(String accessToken, String refreshToken) {
+        return new MemberLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/member/application/service/ManagerService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/ManagerService.java
@@ -10,6 +10,7 @@ import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoListRe
 import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,12 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ManagerService {
     private final MemberRepository memberRepository;
     private final MemberValidator memberValidator;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     public void createManager(MemberCreateRequest request) {
         memberValidator.assertEmailIsNotTaken(request.email());
         memberRepository.save(
                 Member.createManager(
-                        request.email(), request.password(), request.name(), request.contact()));
+                        request.email(),
+                        passwordEncoder.encode(request.password()),
+                        request.name(),
+                        request.contact()));
     }
 
     @Transactional(readOnly = true)
@@ -58,7 +63,7 @@ public class ManagerService {
     public void changeManagerPassword(Long memberId, MemberPasswordUpdateRequest request) {
         Member member = memberValidator.getMemberById(memberId);
         memberValidator.validatePassword(request.originalPassword(), request.newPassword(), member);
-        member.updatePassword(request.newPassword());
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
     } // 추후 BCryptEncoder 사용한 암/복호화 검증 로직 적용 예정
 
     public void removeManager(Long memberId) {

--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -8,6 +8,7 @@ import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateR
 import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,19 +18,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberValidator memberValidator;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     public void createCustomer(MemberCreateRequest request) {
         memberValidator.assertEmailIsNotTaken(request.email());
         memberRepository.save(
                 Member.createCustomer(
-                        request.email(), request.password(), request.name(), request.contact()));
+                        request.email(),
+                        passwordEncoder.encode(request.password()),
+                        request.name(),
+                        request.contact()));
     }
 
     public void createOwner(MemberCreateRequest request) {
         memberValidator.validateNewOwnerRegistration(request.email());
         memberRepository.save(
                 Member.createOwner(
-                        request.email(), request.password(), request.name(), request.contact()));
+                        request.email(),
+                        passwordEncoder.encode(request.password()),
+                        request.name(),
+                        request.contact()));
     }
 
     @Transactional(readOnly = true)
@@ -47,7 +55,7 @@ public class MemberService {
     public void changeMemberPassword(MemberPasswordUpdateRequest request) {
         Member member = memberValidator.getCurrentMember();
         memberValidator.validatePassword(request.originalPassword(), request.newPassword(), member);
-        member.updatePassword(request.newPassword());
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
     } // 추후 BCryptEncoder 사용한 암/복호화 검증 로직 적용 예정
 
     public void changeCustomerRoleToOwner() {

--- a/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
@@ -11,12 +11,14 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class MemberValidator {
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
 
     public Member getCurrentMember() {
         return memberRepository
@@ -45,11 +47,22 @@ public class MemberValidator {
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
     } // 타 사용자의 정보 조회(MANAGER, MASTER 권한)
 
+    public Member getMemberByEmail(String email) {
+        return memberRepository
+                .findMemberByEmail(email)
+                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+    } // 로그인 된 유저 정보 조회
+
     public void validatePassword(String originalPassword, String newPassword, Member member) {
-        if (member.getPassword().equals(originalPassword))
+        if (!passwordEncoder.matches(originalPassword, member.getPassword()))
             throw new CommonException(MemberErrorCode.INVALID_PASSWORD);
-        if (member.getPassword().equals(newPassword))
+        if (passwordEncoder.matches(newPassword, member.getPassword()))
             throw new CommonException(MemberErrorCode.DUPLICATED_PASSWORD);
+    }
+
+    public void assertPassword(String password, Member member) {
+        if (!passwordEncoder.matches(password, member.getPassword()))
+            throw new CommonException(MemberErrorCode.INVALID_PASSWORD);
     }
 
     public void validateNewOwnerRegistration(String email) {

--- a/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
@@ -4,9 +4,13 @@ import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
 import com.irum.come2us.domain.member.domain.repository.MemberRepository;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.AuthErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.security.MemberDetails;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,15 +20,30 @@ public class MemberValidator {
 
     public Member getCurrentMember() {
         return memberRepository
-                .findByMemberId(1L)
+                .findByMemberId(getCurrentMemberId())
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-    } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
+    } // 로그인 된 유저 정보 조회
+
+    private Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+        try {
+            MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+            return Long.parseLong(memberDetails.getUsername());
+        } catch (ClassCastException e) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        } catch (Exception e) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+    }
 
     public Member getMemberById(Long memberId) {
         return memberRepository
                 .findByMemberId(memberId)
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-    } // Spring Security 도입 후 SecurityContextHolder를 통해 검증하도록 변경 예정
+    } // 타 사용자의 정보 조회(MANAGER, MASTER 권한)
 
     public void validatePassword(String originalPassword, String newPassword, Member member) {
         if (member.getPassword().equals(originalPassword))

--- a/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/entity/Member.java
@@ -2,7 +2,7 @@ package com.irum.come2us.domain.member.domain.entity;
 
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
 import com.irum.come2us.global.constants.RegexConstants;
-import com.irum.come2us.global.domain.BaseEntity;
+import com.irum.come2us.global.domain.BaseTimeEntity;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import jakarta.persistence.*;
@@ -20,7 +20,7 @@ import org.hibernate.annotations.Where;
 @SQLDelete(sql = "UPDATE p_member SET deleted_at = NOW() WHERE member_id = ?")
 @Where(clause = "deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity {
+public class Member extends BaseTimeEntity {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/irum/come2us/domain/member/domain/entity/enums/Role.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/entity/enums/Role.java
@@ -1,8 +1,15 @@
 package com.irum.come2us.domain.member.domain.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Role {
-    CUSTOMER,
-    OWNER,
-    MANAGER,
-    MASTER
+    CUSTOMER("ROLE_CUSTOMER"),
+    OWNER("ROLE_OWNER"),
+    MANAGER("ROLE_MANAGER"),
+    MASTER("ROLE_MASTER");
+
+    private final String authority;
 }

--- a/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/irum/come2us/domain/member/domain/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByMemberId(Long memberId);
+
+    Optional<Member> findMemberByEmail(String email);
 }

--- a/src/main/java/com/irum/come2us/global/constants/SecurityConstants.java
+++ b/src/main/java/com/irum/come2us/global/constants/SecurityConstants.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.global.constants;
+
+public final class SecurityConstants {
+    public static final String TOKEN_ROLE_NAME = "authority";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+}

--- a/src/main/java/com/irum/come2us/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/irum/come2us/global/domain/BaseTimeEntity.java
@@ -3,20 +3,23 @@ package com.irum.come2us.global.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @MappedSuperclass
-public class BaseEntity extends BaseTimeEntity {
-    @CreatedBy
+public class BaseTimeEntity {
+    @CreatedDate
     @Column(updatable = false, nullable = false)
-    private Long createdBy;
+    private LocalDateTime createdAt;
 
-    @LastModifiedBy
+    @LastModifiedDate
     @Column(nullable = false)
-    private Long updatedBy;
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,15 @@
+package com.irum.come2us.global.infrastructure.config.jpa;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+    @Bean
+    public AuditorAware<Long> auditorProvider() {
+        return new MemberAuditorAware();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/MemberAuditorAware.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/jpa/MemberAuditorAware.java
@@ -1,0 +1,28 @@
+package com.irum.come2us.global.infrastructure.config.jpa;
+
+import com.irum.come2us.global.security.MemberDetails;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class MemberAuditorAware implements AuditorAware<Long> {
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || authentication.getPrincipal() == null
+                || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+        if (authentication.getPrincipal() instanceof MemberDetails) {
+            MemberDetails nowMember = (MemberDetails) authentication.getPrincipal();
+            Long memberId = Long.parseLong(nowMember.getUsername());
+            log.info("현재 유저: {}", nowMember.getUsername());
+            return Optional.of(memberId);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
@@ -1,0 +1,67 @@
+package com.irum.come2us.global.infrastructure.config.security;
+
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.addExposedHeader("Authorization");
+        config.addAllowedOrigin("http://localhost:8080");
+        config.setMaxAge(3600L); // Preflight 캐시 허용 1시간
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(
+                auth ->
+                        auth // API 개발 완료 후 비즈니스 로직에 맞게 설정 변경 예정
+                                .requestMatchers("/members")
+                                .hasAnyRole(
+                                        Role.CUSTOMER.name(),
+                                        Role.OWNER.name(),
+                                        Role.MANAGER.name(),
+                                        Role.MASTER.name())
+                                .requestMatchers(HttpMethod.DELETE, "/members/me")
+                                .hasRole(String.valueOf(Role.CUSTOMER))
+                                .requestMatchers("/managers/**")
+                                .hasRole(String.valueOf(Role.MASTER))
+                                .anyRequest()
+                                .permitAll()); // API 완료 후 허용된 public endpoints 외 모든 경로
+        // .authenticated() 옵션으로 변경할 예정
+        return http.build();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/config/security/SecurityConfig.java
@@ -1,6 +1,11 @@
 package com.irum.come2us.global.infrastructure.config.security;
 
+import com.irum.come2us.domain.auth.application.service.JwtTokenService;
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.security.JwtAuthenticationFilter;
+import com.irum.come2us.global.util.CookieUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -10,13 +15,18 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -62,6 +72,19 @@ public class SecurityConfig {
                                 .anyRequest()
                                 .permitAll()); // API 완료 후 허용된 public endpoints 외 모든 경로
         // .authenticated() 옵션으로 변경할 예정
+
+        http.addFilterBefore(
+                jwtAuthenticationFilter(memberRepository, jwtTokenService, cookieUtil),
+                UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            MemberRepository memberRepository,
+            JwtTokenService jwtTokenService,
+            CookieUtil cookieUtil) {
+        return new JwtAuthenticationFilter(memberRepository, jwtTokenService, cookieUtil);
     }
 }

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/JwtProperties.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String accessTokenSecret,
+        String refreshTokenSecret,
+        Long accessTokenExpirationTime,
+        Long refreshTokenExpirationTime,
+        String issuer) {
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/PropertiesConfig.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/PropertiesConfig.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({JwtProperties.class, RedisProperties.class})
+@Configuration
+public class PropertiesConfig {}

--- a/src/main/java/com/irum/come2us/global/infrastructure/properties/RedisProperties.java
+++ b/src/main/java/com/irum/come2us/global/infrastructure/properties/RedisProperties.java
@@ -1,0 +1,6 @@
+package com.irum.come2us.global.infrastructure.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(String host, int port, String password) {}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+    AUTHENTICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/AuthErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseErrorCode {
-    AUTHENTICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보가 존재하지 않습니다.");
+    AUTHENTICATION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보가 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/irum/come2us/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/irum/come2us/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,124 @@
+package com.irum.come2us.global.security;
+
+import static com.irum.come2us.global.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+import static com.irum.come2us.global.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.irum.come2us.domain.auth.application.service.JwtTokenService;
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.util.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+        String refreshTokenCookieValue = extractRefreshTokenFromCookie(request);
+
+        // 헤더에 AT가 있으면 우선적으로 검증
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+            // AT가 유효하면 통과
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.memberId(), accessTokenDto.role());
+
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        // AT가 유효하지 않다면 RT 파싱
+        if (refreshTokenCookieValue != null) {
+            RefreshTokenDto refreshTokenDto =
+                    jwtTokenService.retrieveRefreshToken(refreshTokenCookieValue);
+
+            // RT가 유효하면 AT, RT 재발급
+            if (refreshTokenDto != null) {
+                Member member =
+                        memberRepository
+                                .findById(refreshTokenDto.memberId())
+                                .orElseThrow(
+                                        () ->
+                                                new CommonException(
+                                                        MemberErrorCode.MEMBER_NOT_FOUND));
+
+                AccessTokenDto reissueAccessTokenDto =
+                        jwtTokenService.createAccessTokenDto(
+                                member.getMemberId(), member.getRole());
+                RefreshTokenDto reissueRefreshTokenDto =
+                        jwtTokenService.createRefreshTokenDto(member.getMemberId());
+
+                HttpHeaders headers =
+                        cookieUtil.generateRefreshTokenCookie(
+                                reissueRefreshTokenDto.refreshTokenValue());
+
+                response.addHeader(
+                        HttpHeaders.AUTHORIZATION,
+                        TOKEN_PREFIX + reissueAccessTokenDto.accessTokenValue());
+                response.addHeader(
+                        HttpHeaders.SET_COOKIE, headers.getFirst(HttpHeaders.SET_COOKIE));
+            }
+        }
+
+        // AT, RT가 모두 만료된 경우 실패
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToken(Long memberId, Role authority) {
+        UserDetails userDetails = new MemberDetails(memberId, authority);
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith(TOKEN_PREFIX)) {
+            return header.replace(TOKEN_PREFIX, "");
+        }
+
+        return null;
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
+
+        if (cookie != null) {
+            return cookie.getValue();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/irum/come2us/global/security/MemberDetails.java
+++ b/src/main/java/com/irum/come2us/global/security/MemberDetails.java
@@ -1,0 +1,31 @@
+package com.irum.come2us.global.security;
+
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class MemberDetails implements UserDetails {
+
+    private final Long memberId;
+    private final Role authority;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(authority.getAuthority()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return memberId.toString();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
@@ -68,6 +68,19 @@ public class JwtUtil {
         }
     }
 
+    public String resolveToken(String headerValue) {
+        if (headerValue != null && headerValue.startsWith("Bearer ")) {
+            return headerValue.substring(7);
+        }
+        return null;
+    }
+
+    public long getRemainingExpirationMillis(String tokenValue) {
+        Jws<Claims> claims = getClaims(tokenValue, getAccessTokenKey());
+        Date exp = claims.getBody().getExpiration();
+        return Math.max(exp.getTime() - System.currentTimeMillis(), 0);
+    }
+
     public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
         try {
             Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());

--- a/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/irum/come2us/global/security/jwt/JwtUtil.java
@@ -1,0 +1,126 @@
+package com.irum.come2us.global.security.jwt;
+
+import static com.irum.come2us.global.constants.SecurityConstants.TOKEN_ROLE_NAME;
+
+import com.irum.come2us.domain.auth.presentation.dto.request.AccessTokenDto;
+import com.irum.come2us.domain.auth.presentation.dto.request.RefreshTokenDto;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.global.infrastructure.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    public AccessTokenDto generateAccessTokenDto(Long memberId, Role authority) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String accessTokenValue = buildAccessToken(memberId, authority, issuedAt, expiredAt);
+        return AccessTokenDto.of(memberId, authority, accessTokenValue);
+    }
+
+    public String generateAccessToken(Long memberId, Role authority) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, authority, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String refreshTokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return RefreshTokenDto.of(
+                memberId, refreshTokenValue, jwtProperties.refreshTokenExpirationTime());
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    Role.valueOf(claims.getBody().get(TOKEN_ROLE_NAME, String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
+
+            return RefreshTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    refreshTokenValue,
+                    jwtProperties.refreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parser()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.refreshTokenExpirationTime();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+
+    private String buildAccessToken(Long memberId, Role authority, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, authority.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+}

--- a/src/main/java/com/irum/come2us/global/util/CookieUtil.java
+++ b/src/main/java/com/irum/come2us/global/util/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.irum.come2us.global.util;
+
+import static com.irum.come2us.global.constants.SecurityConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                        .path("/")
+                        .secure(true)
+                        .sameSite(determineSameSitePolicy())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    public HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(true)
+                        .sameSite(determineSameSitePolicy())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+
+    private String determineSameSitePolicy() {
+        return Cookie.SameSite.NONE.attributeValue();
+    }
+}

--- a/src/main/resources/application-redis.yaml
+++ b/src/main/resources/application-redis.yaml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application-security.yaml
+++ b/src/main/resources/application-security.yaml
@@ -1,0 +1,6 @@
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER:irum}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #58 

📌 **작업 내용 및 특이사항**
## Spring Security
- Security Config 
- JWT 기반 Filterchain 구현
- CORS Config 작성
- URL 패턴 기반 RequestMatcher 구현(Member 도메인 일부 API 제외하고 모두 허용한 상태-추후 API 개발 완료되면 최신화 예정)

## JWT Authentication
- JWT 기반 인증 필터 구현
- Access Token, Refresh Token 생성/파싱 유틸 구현


## JPA Audit
- JpaAuditingConfig & AuditorAware 클래스 구현(Member Long 타입 아이디를 Base엔티티의 생성/수정 행위자로 업데이트)
- BaseEntity와 BaseTimeEntity 분리, BaseEntity는 BaseTimeEntity를 상속 Member 와 같이, 생성 시점에서 사용자의 인증 정보가 존재할 수 없는 도메인의 경우 고려해야 함
- 상속 관계: BaseTimeEntity > BaseEntity > Product, Review 등등 멤버 로그인 한 이후 생성하는 도메인들

## Member Login/Logout
- 기존 문자열 기반 password 비교/검증 로직에 BCryptEncoder 도입
- Login: AccessToken, RefreshToken 반환
- RefreshToken의 경우 Cookie 로 변환하여 요청에 대한 응답 헤더/본문에 노출되지 않도록 구현
- Logout: Redis 저장된 RefreshToken 삭제

📚 **참고사항**
- BaseEntity 분리된 건 반드시 확인 바랍니다.
- 기존 AccessToken BlackList 등록 로직은 모든 요청 시 Redis 조회 트래픽 발생 및 무상태성 위반 이슈로 제거하였습니다.