### PR TITLE
[Chore] Spring REST Docs 문서 자동화 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '7.2.1'
+    id 'org.asciidoctor.jvm.convert' version '4.0.5'
 }
 
 group = 'com.irum'
@@ -19,6 +20,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -26,6 +28,7 @@ repositories {
 }
 
 def querydslDirProperty = layout.buildDirectory.dir("generated/querydsl")
+def snippetsDir = layout.buildDirectory.dir("generated-snippets")
 
 sourceSets {
     main {
@@ -60,8 +63,37 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+//Spring REST Docs & asciidoctor 설정
+test {
+    useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+asciidoctor.doFirst {
+    delete layout.projectDirectory.dir("src/main/resources/static/docs")
+}
+
+asciidoctor {
+    // 'snippets' 변수에 'snippetsDir' 경로(build/generated-snippets)를 주입
+    attributes(
+            'snippets': snippetsDir.get().asFile
+    )
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+bootJar {
+    if (project.hasProperty('docs')) {
+        dependsOn asciidoctor
+    }
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,25 @@
+= Come2Us API 명세서 =
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+== 회원 (Member) API
+
+=== 1. 고객 회원가입
+
+`POST /members/signup`
+
+==== 요청 본문 (Request Body)
+include::{snippets}/member-signup/request-fields.adoc[]
+
+==== 예시 요청 (cURL)
+include::{snippets}/member-signup/curl-request.adoc[]
+
+==== 예시 요청 (HTTPie)
+include::{snippets}/member-signup/httpie-request.adoc[]
+
+==== 응답 (Response)
+include::{snippets}/member-signup/http-response.adoc[]

--- a/src/test/java/com/irum/come2us/domain/member/MemberControllerTest.java
+++ b/src/test/java/com/irum/come2us/domain/member/MemberControllerTest.java
@@ -1,0 +1,73 @@
+package com.irum.come2us.domain.member;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.irum.come2us.domain.member.application.service.MemberService;
+import com.irum.come2us.domain.member.presentation.controller.MemberController;
+import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureRestDocs
+public class MemberControllerTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private MemberService memberService;
+
+    @Autowired private ObjectMapper objectMapper; // Request DTO를 JSON으로 변환
+
+    @TestConfiguration
+    static class TestConfig {
+
+        // MemberService 타입의 Bean을 Mockito로 직접 생성하여 반환
+        @Bean
+        public MemberService memberService() {
+            return Mockito.mock(MemberService.class);
+        }
+    }
+
+    @Test
+    @DisplayName("고객 회원가입 API 문서 생성")
+    void customerSignupApiTest() throws Exception {
+
+        // Given
+        MemberCreateRequest request =
+                new MemberCreateRequest(
+                        "customer@example.com", "password123!", "회원1", "010-1234-5678");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // 5. [동일] 주입받은 memberService(Mock 객체)를 사용해 Mocking합니다.
+        doNothing().when(memberService).createCustomer(any(MemberCreateRequest.class));
+
+        // When & Then
+        mockMvc.perform(
+                        post("/members/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestJson))
+                .andExpect(status().isCreated())
+                .andDo(
+                        document(
+                                "member-signup",
+                                requestFields(
+                                        fieldWithPath("email").description("가입할 이메일 (아이디)"),
+                                        fieldWithPath("password").description("가입할 비밀번호"),
+                                        fieldWithPath("name").description("사용자 이름"),
+                                        fieldWithPath("contact")
+                                                .description("사용자 연락처 (e.g., 010-1234-5678)"))));
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #20 

📌 **작업 내용 및 특이사항**

- Spring REST Docs API 명세 자동 생성 구현
<img width="1569" height="1010" alt="image" src="https://github.com/user-attachments/assets/abaf8230-c0a5-48d5-9703-3cba7018b095" />

## How To
1. @AutoConfigureRestDocs 포함하여 WebMvcTest 작성
2. src/docs/asciidocs/index.adocs 파일 수정하여 코드스니펫 본문 추가
<img width="734" height="425" alt="image" src="https://github.com/user-attachments/assets/9f8b1112-4c74-4a75-8d17-294a813ff3ee" />

3. `$./gradlew build -Pdocs ` 명령어 실행
<img width="502" height="466" alt="image" src="https://github.com/user-attachments/assets/e8b36de6-7507-4b2e-9b1f-f78e5c714f93" />


5. build/docs/asciidocs/index.html 자동생성 확인
<img width="330" height="109" alt="image" src="https://github.com/user-attachments/assets/278b6ec0-fade-459c-bb70-56eae303d9c9" />

7. 브라우저에서 열거나 파일 저장하여 확인


📚 **참고사항**
- 추후 Swagger UI 등 적용 예정