### PR TITLE
[Feature] #47 상점 목록 조회(QueryDSL), 상점 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/store/application/service/StoreService.java
+++ b/src/main/java/com/irum/come2us/domain/store/application/service/StoreService.java
@@ -6,6 +6,7 @@ import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreCreateRequest;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreUpdateRequest;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreInfoResponse;
 import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
@@ -64,8 +65,12 @@ public class StoreService {
             size = 10;
         }
 
-        List<StoreListResponse> stores = storeRepository.findStoresByCursor(cursor, size);
-        return stores;
+        return storeRepository.findStoresByCursor(cursor, size);
+    }
+
+    public StoreInfoResponse getStoreInfo(UUID storeId) {
+        Store store = getStoreById(storeId);
+        return StoreInfoResponse.from(store);
     }
 
     // 권한 체크

--- a/src/main/java/com/irum/come2us/domain/store/application/service/StoreService.java
+++ b/src/main/java/com/irum/come2us/domain/store/application/service/StoreService.java
@@ -6,9 +6,11 @@ import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreCreateRequest;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreUpdateRequest;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,6 +57,15 @@ public class StoreService {
         Store store = getStoreById(storeId);
         // TODO: 권한 체크
         storeRepository.delete(store);
+    }
+
+    public List<StoreListResponse> getStoreList(UUID cursor, Integer size) {
+        if (size == null || (size != 10 && size != 30 && size != 50)) {
+            size = 10;
+        }
+
+        List<StoreListResponse> stores = storeRepository.findStoresByCursor(cursor, size);
+        return stores;
     }
 
     // 권한 체크

--- a/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepository.java
@@ -5,7 +5,7 @@ import com.irum.come2us.domain.store.domain.entity.Store;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends JpaRepository<Store, UUID> {
+public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
 
     boolean existsByMember(Member member);
 

--- a/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.store.domain.repository;
+
+import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
+import java.util.List;
+import java.util.UUID;
+
+public interface StoreRepositoryCustom {
+    List<StoreListResponse> findStoresByCursor(UUID cursor, int size);
+}

--- a/src/main/java/com/irum/come2us/domain/store/infrastructure/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/store/infrastructure/repository/StoreRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.irum.come2us.domain.store.infrastructure.repository;
+
+import com.irum.come2us.domain.store.domain.entity.QStore;
+import com.irum.come2us.domain.store.domain.repository.StoreRepositoryCustom;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreRepositoryImpl implements StoreRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StoreListResponse> findStoresByCursor(UUID cursor, int size) {
+        QStore store = QStore.store;
+
+        var query = queryFactory.selectFrom(store).orderBy(store.id.desc()).limit(size);
+
+        if (cursor != null) {
+            query.where(store.id.lt(cursor));
+        }
+
+        return query.fetch().stream().map(StoreListResponse::from).toList();
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/irum/come2us/domain/store/presentation/controller/StoreController.java
@@ -4,7 +4,9 @@ import com.irum.come2us.domain.store.application.service.StoreService;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreCreateRequest;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreUpdateRequest;
 import com.irum.come2us.domain.store.presentation.dto.response.StoreCreateResponse;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,5 +46,14 @@ public class StoreController {
         log.info("상점 삭제 요청 : storeId={}", storeId);
         storeService.deleteStore(storeId);
         return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @GetMapping
+    public ResponseEntity<List<StoreListResponse>> getStoreList(
+            @RequestParam(required = false) UUID cursor,
+            @RequestParam(required = false) Integer size) {
+        log.info("상점 목록 조회 요청: cursor={}, size={}", cursor, size);
+        List<StoreListResponse> response = storeService.getStoreList(cursor, size);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/irum/come2us/domain/store/presentation/controller/StoreController.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.store.application.service.StoreService;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreCreateRequest;
 import com.irum.come2us.domain.store.presentation.dto.request.StoreUpdateRequest;
 import com.irum.come2us.domain.store.presentation.dto.response.StoreCreateResponse;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreInfoResponse;
 import com.irum.come2us.domain.store.presentation.dto.response.StoreListResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -54,6 +55,13 @@ public class StoreController {
             @RequestParam(required = false) Integer size) {
         log.info("상점 목록 조회 요청: cursor={}, size={}", cursor, size);
         List<StoreListResponse> response = storeService.getStoreList(cursor, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<StoreInfoResponse> getStoreDetail(@PathVariable UUID storeId) {
+        log.info("상점 상세 조회 요청: storeId={}", storeId);
+        StoreInfoResponse response = storeService.getStoreInfo(storeId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/store/presentation/dto/response/StoreInfoResponse.java
+++ b/src/main/java/com/irum/come2us/domain/store/presentation/dto/response/StoreInfoResponse.java
@@ -1,0 +1,24 @@
+package com.irum.come2us.domain.store.presentation.dto.response;
+
+import com.irum.come2us.domain.store.domain.entity.Store;
+import java.util.UUID;
+
+public record StoreInfoResponse(
+        UUID id,
+        String name,
+        String contact,
+        String address,
+        int deliveryFee,
+        String businessRegistrationNumber,
+        String telemarketingRegistrationNumber) {
+    public static StoreInfoResponse from(Store store) {
+        return new StoreInfoResponse(
+                store.getId(),
+                store.getName(),
+                store.getContact(),
+                store.getAddress(),
+                store.getDeliveryFee(),
+                store.getBusinessRegistrationNumber(),
+                store.getTelemarketingRegistrationNumber());
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/store/presentation/dto/response/StoreListResponse.java
+++ b/src/main/java/com/irum/come2us/domain/store/presentation/dto/response/StoreListResponse.java
@@ -1,0 +1,16 @@
+package com.irum.come2us.domain.store.presentation.dto.response;
+
+import com.irum.come2us.domain.store.domain.entity.Store;
+import java.util.UUID;
+
+public record StoreListResponse(
+        UUID id, String name, String contact, String address, int deliveryFee) {
+    public static StoreListResponse from(Store store) {
+        return new StoreListResponse(
+                store.getId(),
+                store.getName(),
+                store.getContact(),
+                store.getAddress(),
+                store.getDeliveryFee());
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #47 

📌 **작업 내용 및 특이사항**
상점 목록 조회(QueryDSL)
상점 상세 조회 기능 구현 (아이디, 상점명, 연락처, 주소, 배송비, 사업등록번호, 통신판매신고번호)

📚 **참고사항**
(예정)
상점 목록 조회같은 경우에는 매니저만 할 수 있게 설정. (-> 일반적으로 소비자가 상점을 조회하지 않는다고 판단해서)