### PR TITLE
[Refactor] Product BaseEntity 상속 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -10,12 +10,12 @@ import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailRe
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -122,6 +122,7 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
+    @Transactional(readOnly = true)
     public ProductCursorResponse getProductList(UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
@@ -142,6 +143,7 @@ public class ProductService {
         return ProductCursorResponse.of(products);
     }
 
+    @Transactional(readOnly = true)
     public ProductDetailResponse getProductById(UUID productId) {
         Product product =
                 productRepository

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -149,4 +149,14 @@ public class ProductService {
 
         return ProductDetailResponse.from(product);
     }
+
+    public void deleteProduct(UUID productId) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        productRepository.delete(product);
+        log.info("상품 삭제 완료: productId={}", productId);
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductCursorResponse;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
@@ -121,7 +122,7 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
-    public List<ProductResponse> getProductList(UUID cursor, Integer size, String keyword) {
+    public ProductCursorResponse getProductList(UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
             size = 10;
@@ -138,7 +139,7 @@ public class ProductService {
         }
 
         log.info("상품 목록 조회 완료: keyword={}, count={}", keyword, products.size());
-        return products;
+        return ProductCursorResponse.of(products);
     }
 
     public ProductDetailResponse getProductById(UUID productId) {

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -1,5 +1,6 @@
 package com.irum.come2us.domain.product.domain.entity;
 
+import com.irum.come2us.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -12,7 +13,7 @@ import org.hibernate.annotations.UuidGenerator;
 @Getter
 @Table(name = "p_product")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Product {
+public class Product extends BaseEntity {
     @Id
     @UuidGenerator(style = UuidGenerator.Style.RANDOM)
     @Column(name = "product_id", updatable = false, nullable = false)

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -7,12 +7,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @Table(name = "p_product")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE p_product SET deleted_at = NOW() WHERE product_id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class Product extends BaseEntity {
     @Id
     @UuidGenerator(style = UuidGenerator.Style.RANDOM)

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.Where;
 @Where(clause = "deleted_at IS NULL")
 public class Product extends BaseEntity {
     @Id
-    @UuidGenerator(style = UuidGenerator.Style.RANDOM)
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
     @Column(name = "product_id", updatable = false, nullable = false)
     private UUID id;
 

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.reviewCount))
                 .from(product)
                 .where(product.isPublic.isTrue(), ltCursor(cursor, product))
-                .orderBy(product.createdAt.desc())
+                .orderBy(product.id.desc())
                 .limit(size)
                 .fetch();
     }
@@ -71,7 +71,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.isPublic.isTrue(),
                         ltCursor(cursor, product),
                         containsKeyword(keyword, product))
-                .orderBy(product.createdAt.desc())
+                .orderBy(product.id.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.reviewCount))
                 .from(product)
                 .where(product.isPublic.isTrue(), ltCursor(cursor, product))
-                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
+                .orderBy(product.createdAt.desc())
                 .limit(size)
                 .fetch();
     }
@@ -71,7 +71,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         product.isPublic.isTrue(),
                         ltCursor(cursor, product),
                         containsKeyword(keyword, product))
-                .orderBy(product.id.desc()) // createdAt 기준 정렬로 변경 예정
+                .orderBy(product.createdAt.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -2,12 +2,12 @@ package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductCursorResponse;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,12 +51,12 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ProductResponse>> getProductList(
+    public ResponseEntity<ProductCursorResponse> getProductList(
             @RequestParam(required = false) UUID cursor,
             @RequestParam(required = false) Integer size,
             @RequestParam(required = false) String keyword) {
         log.info("상품 목록 조회 요청: cursor={}, size={}, keyword={}", cursor, size, keyword);
-        List<ProductResponse> response = productService.getProductList(cursor, size, keyword);
+        ProductCursorResponse response = productService.getProductList(cursor, size, keyword);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -67,4 +67,11 @@ public class ProductController {
         ProductDetailResponse response = productService.getProductById(productId);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable UUID productId) {
+        log.info("상품 삭제 요청: productId={}", productId);
+        productService.deleteProduct(productId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCursorResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCursorResponse.java
@@ -1,0 +1,12 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import java.util.List;
+import java.util.UUID;
+
+public record ProductCursorResponse(List<ProductResponse> products, UUID nextCursor) {
+    public static ProductCursorResponse of(List<ProductResponse> products) {
+        UUID nextCursor = products.isEmpty() ? null : products.get(products.size() - 1).id();
+        return new ProductCursorResponse(products, nextCursor);
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #90 

📌 **작업 내용 및 특이사항**
- 기존 ProductEntity에 BaseEntity 상속
- Audit Field 연결 확인 완료 (createdAt, updatedAt, createdBy, updatedBy)
  - 상품 정렬 생성일자 기준으로 변경
- ProductEntity에 Soft Delete 적용
  - `@SQLDelete`, `@Where`
- Product 삭제 로직 구현
  - Controller, Service

📚 **참고사항**
- BaseEntity 상속으로 인해 createdBy, updatedBy 필드 추가 -> .env 파일과 redis 필요 (노션 작성)
- 사용자 권한에 따른 상품 접근 제한 추가 예정

---

📌 **작업 내용 및 특이사항**
- UUID 생성전략 변경 `UUIDv4`->`UUIDv7`
  - `UUIDv7` 적용으로 시간순 정렬 보장 및 인덱싱 효율성 향상
- 커서 기반 조회 시, 마지막 상품 UUID(`nextCursor`)를 함께 반환하도록 구조 변경

- ProductCursorResponse DTO 추가
  - List<ProductResponse> + nextCursor(UUID) 반환
  - 마지막 상품의 UUID를 기반으로 다음 페이지 조회 가능
- ProductService
  - 반환 타입을 List<ProductResponse> -> ProductCursorResponse로 변경
  - 커서 기반 조회(ltCursor) 로직 완성
- ProductController
  - 응답 타입 변경 (ResponseEntity<ProductCursorResponse>) 

📚 **참고사항**


✅ 응답 예시
`GET /products`
```
{
    "success": true,
    "status": 200,
    "data": {
        "products": [
            {
                "id": "ac10189b-9a05-1984-819a-050b40c4000c",
                ...
            },
                ...
            {
                "id": "ac10189b-9a05-1984-819a-050a19b10003",
                ...
            }
        ],
        "nextCursor": "ac10189b-9a05-1984-819a-050a19b10003"
    },
    "timestamp": "2025-10-21T13:45:21.473571"
}
```

`GET /products?cursor=ac10189b-9a05-1984-819a-050a19b10003`
```
{
    "success": true,
    "status": 200,
    "data": {
        "products": [
            {
                "id": "ac10189b-9a05-1984-819a-050a176b0002",
                ...
            },
                ...
            {
                "id": "ac10189b-9a05-1984-819a-050a08390000",
                ...
            }
        ],
        "nextCursor": "ac10189b-9a05-1984-819a-050a08390000"
    },
    "timestamp": "2025-10-21T13:47:16.870112"
}
```