### PR TITLE
[Feature] 상품 옵션 도메인 & 정적 팩토리 메서드 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -1,6 +1,8 @@
 package com.irum.come2us.domain.product.domain.entity;
 
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,8 +32,6 @@ public class Product {
     @Column(name = "is_public", nullable = false)
     private boolean isPublic;
 
-    // enum 생성
-
     @Column(name = "avg_rating")
     private Double avgRating;
 
@@ -40,6 +40,9 @@ public class Product {
 
     @Column(name = "price", nullable = false)
     private int price;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductOptionGroup> optionGroups = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)
     private Product(
@@ -88,5 +91,9 @@ public class Product {
         this.reviewCount = reviewCount;
     }
 
-    // TODO: Store, Category, 이미지, 옵션 매핑
+    public void addOptionGroup(ProductOptionGroup group) {
+        optionGroups.add(group);
+    }
+
+    // TODO: Store, Category, 이미지 매핑
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionGroup.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionGroup.java
@@ -1,0 +1,52 @@
+package com.irum.come2us.domain.product.domain.entity;
+
+import com.irum.come2us.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_product_option_group")
+@SQLDelete(sql = "UPDATE p_product_option_group SET deleted_at = NOW() WHERE option_group_id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class ProductOptionGroup extends BaseEntity {
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.RANDOM)
+    @Column(name = "option_group_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @OneToMany(mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductOptionValue> optionValues = new ArrayList<>();
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ProductOptionGroup(Product product, String name) {
+        this.product = product;
+        this.name = name;
+    }
+
+    public static ProductOptionGroup createOptionGroup(Product product, String name) {
+        return ProductOptionGroup.builder().product(product).name(name).build();
+    }
+
+    public void addOptionValue(ProductOptionValue value) {
+        optionValues.add(value);
+        value.setOptionGroup(this);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionValue.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionValue.java
@@ -1,0 +1,65 @@
+package com.irum.come2us.domain.product.domain.entity;
+
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "p_product_option_value")
+@SQLDelete(sql = "UPDATE p_product_option_value SET deleted_at = NOW() WHERE option_value_id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class ProductOptionValue {
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.RANDOM)
+    @Column(name = "option_value_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_group_id", nullable = false)
+    private ProductOptionGroup optionGroup;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "stock_quantity", nullable = false)
+    private int stockQuantity;
+
+    @Column(name = "extra_price")
+    private Integer extraPrice;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ProductOptionValue(
+            ProductOptionGroup optionGroup, String name, int stockQuantity, int extraPrice) {
+        this.optionGroup = optionGroup;
+        this.name = name;
+        this.stockQuantity = stockQuantity;
+        this.extraPrice = extraPrice;
+    }
+
+    public static ProductOptionValue createOptionValue(
+            ProductOptionGroup group, String name, int stockQuantity, int extraPrice) {
+        ProductOptionValue value =
+                ProductOptionValue.builder()
+                        .optionGroup(group)
+                        .name(name)
+                        .stockQuantity(stockQuantity)
+                        .extraPrice(extraPrice)
+                        .build();
+        group.addOptionValue(value);
+        return value;
+    }
+
+    protected void setOptionGroup(ProductOptionGroup optionGroup) {
+        this.optionGroup = optionGroup;
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #91 

📌 **작업 내용 및 특이사항**
- ProductOptionGroup, ProductionOptionValue 엔티티 생성
- Product 엔티티에 옵션 그룹 연관관계 매핑 추가
  - 1:N 관계
  - 상품 삭제 시 옵션 그룹 및 옵션 값 자동 삭제 처리
- 메서드 추가
  - `createOptionGroup`, `createOptionValue`
  - `addOptionGroup`, `addOptionValue`
  - 상품 생성 시 옵션 그룹 및 옵션 값을 함께 등록할 수 있도록 설계

📚 **참고사항**
- Product 생성 시 옵션 그룹 및 옵션 값까지 함께 등록할 수 있도록 Request와 Service 확장 예정
- Product에 BaseEntity 상속 및 Soft Delete는 #90 이 아직 develop으로 머지되지 않아 현 브랜치에서 적용되지 않음
- Review 엔티티에서 `columnDefinition = "TINYINT"`이 Postgre에서는 호환되지 않아 에러가 발생하는 이슈가 있었음
```
    @Column(name = "rate", nullable = false, columnDefinition = "TINYINT")
    private Integer rate;
```