### PR TITLE
[Chore] logback-spring.xml 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 ### VS Code ###
 .vscode/
 .env
+
+### logs ###
+/logs

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,9 +5,7 @@ spring:
   profiles:
     active: local
     include:
-#?? redis, cloud ?? ??? ? ??
 
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql: trace
+
+logback:
+  log-path: ./logs

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,7 +24,7 @@
         <append>false</append>
         -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/com2us.app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/come2us.app.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
@@ -63,7 +63,7 @@
         <appender-ref ref="CONSOLE" />
     </logger>
 
-    // PA Hibernate SQL 실제 타입 바인딩: TRACE
+    // JPA Hibernate SQL 실제 타입 바인딩: TRACE
     <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
         <appender-ref ref="CONSOLE" />
     </logger>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+    <springProperty scope="context" name="LOG_DIR"
+                    source="logback.log-path"
+                    defaultValue="logs"/>
+    <property name="LOG_PATTERN" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
+
+    //IDE 출력 설정
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+    <!--
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+    </appender>
+    -->
+
+    //로그파일 생성 설정
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/come2us.log</file>
+        <!--
+        <append>false</append>
+        -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/com2us.app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    //에러 로그 필터링 설정
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>  <onMismatch>DENY</onMismatch> </filter>
+
+        <file>${LOG_DIR}/error.log</file>
+        <!--
+        <append>false</append>
+        -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>60</maxHistory> </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    //logger 레벨 설정
+    // application: DEBUG
+    <logger name="com.irum.come2us" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+        <appender-ref ref="ERROR_FILE" />
+    </logger>
+
+    // JPA Hibernate SQL 쿼리: DEBUG
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    // PA Hibernate SQL 실제 타입 바인딩: TRACE
+    <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    // 기타 외부 의존성: INFO
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+        <appender-ref ref="ERROR_FILE" />
+    </root>
+
+    //프로필 별 설정
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+            <!--
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+            -->
+        </root>
+        <logger name="com.irum.come2us" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE" />
+            <!--
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+            -->
+        </logger>
+    </springProfile>
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+        </root>
+        <logger name="com.irum.come2us" level="INFO" additivity="false">
+            <appender-ref ref="FILE" />
+            <appender-ref ref="ERROR_FILE" />
+        </logger>
+    </springProfile>
+
+
+</configuration>


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #133 

📌 **작업 내용 및 특이사항**
- Logback은 Slf4j 인터페이스의 구현체
- 기존 개발 과정에서 log.info() , log.warn() 등으로 출력한 모든 로그를 출력하는 로거
- SpringBoot Starter 의존성에 이미 포함되어 있지만, 해당 xml을 통해 application.yaml 기반 logger 설정보다 더 세밀히 로그 정책을 조절하기 위함
- 실행 중 생성되는 모든 정적인 로그 파일들 올라가지 않도록 /logs 폴더 .`gitignore` 등록

## 변수 선언
- 로그 출력 경로, 로그 패턴 등 정의
- <springProperty> 태그로 application.yaml 파일에서 환경변수 불러올 수 있음
- 현재 루트 기준 **./logs** 에 파일 관리되도록 설정


## 공통 Appender 정의
### 1. CONSOLE (IDE 터미널 출력)
- Spring Boot 기본 콘솔 Appender (console-appender.xml) include하여 사용
- 로그 템플릿, 로깅 레벨 등 커스텀 필요할 시 STDOUT appender 주석 해제하고 수정

### 2. FILE (일반 로그 파일)
- 파일명 `com2us.log`
- Rolling 정책: 매일 자정(00:00) 일별 로그 파일 아카이빙 
-  ex) `com2us.log`에 누적된 로그를`come2us.2025-10-21.log` 파일로 2025.10.22 00:00에 생성
- 이후 `com2us.log` 로그 모두 지우고 10.22로그 기록 시작
- 생성된 아카이빙 파일은 최대 30일 보관 후 자동삭제(maxHistory 옵션 통해 수정)
<img width="331" height="90" alt="image" src="https://github.com/user-attachments/assets/6e448b84-3337-48b3-82b7-e004aea845b7" />


### 3. ERROR_FILE (에러 로그 파일)
- 파일명 `error.log`
- ERROR 레벨 로그만 필터링하여 모아두는 파일

## 환경별 로거 동작 (Profiles)
### local (개발 환경)
- 현재 상태
- 콘솔에만 로그 출력하도록 제한한 상태

### prod (운영 환경)
- 현재 운영환경 프로필은 작성되어있지 않음
- 모든 레벨에서 파일로 기록하도록 설정, 필요 시 콘솔 로그 출력 설정도 가능

### 기타
- JPA Hibernate SQL 출력: `DEBUG`
- JPA Hibernate typ: `TRACE`
- CONSOLE로만 출력
- 기존 설정과 동일하게 유지
<img width="385" height="94" alt="image" src="https://github.com/user-attachments/assets/8d1514de-b6e4-4bed-85aa-504928c98f37" />


📚 **참고사항**
- <append>false</append> 옵션:  어플리케이션 재실행 시 모든 로그 삭제하고 누적없이 새 로그 기록
- 로그레벨 순서(내용의 상세함==양): `TRACE`>`DEBUG`>`INFO`>`WARN`>`ERROR`
- !기본 레벨을 DEBUG나 TRACE로 설정하면 로그에 파묻혀 정작 봐야 할 INFO 등 출력값을 찾기 힘들어질 수 있으니 주의

