### PR TITLE
[Feature] Category crud 개발

### DIFF
--- a/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
+++ b/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
@@ -1,8 +1,11 @@
 package com.irum.come2us.domain.category.application.service;
 
+import com.irum.come2us.domain.category.domain.entity.Category;
 import com.irum.come2us.domain.category.domain.repository.CategoryRepository;
+import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,31 +18,70 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    // ✅ 전체 카테고리 조회
+    // ------------------- 전체 조회 -------------------
     public List<CategoryResponse> findAllCategories() {
         return categoryRepository.findAll().stream()
                 .map(CategoryResponse::fromEntity)
                 .collect(Collectors.toList());
     }
 
-    // ✅ 카테고리 생성
-    //    public Category create(CategoryCreateRequest request) {
-    //        Category category;
-    //
-    //        if (request.getParentId() == null) {
-    //            category = Category.createRootCategory(request.getName());
-    //        } else {
-    //            Category parent =
-    //                    categoryRepository
-    //                            .findById(request.getParentId())
-    //                            // 🔹 CustomException → CommonException 으로 변경
-    //                            .orElseThrow(
-    //                                    () ->
-    //                                            new CommonException(
-    //                                                    GlobalErrorCode.INTERNAL_SERVER_ERROR));
-    //            category = Category.createSubCategory(request.getName(), parent);
-    //        }
-    //
-    //        return categoryRepository.save(category);
-    //    }
+    // ------------------- 단일 조회 -------------------
+    public CategoryResponse getCategoryById(UUID id) {
+        Category category =
+                categoryRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("Category not found: " + id));
+        return CategoryResponse.fromEntity(category);
+    }
+
+    // ------------------- 트리 조회 -------------------
+    public List<CategoryResponse> findCategoryTree() {
+        List<Category> roots = categoryRepository.findByParentIsNull();
+        return roots.stream()
+                .map(CategoryResponse::fromEntityWithChildren)
+                .collect(Collectors.toList());
+    }
+
+    // ------------------- 생성 -------------------
+    public Category create(CategoryCreateRequest request) {
+        Category category;
+
+        if (request.parentId() == null) {
+            category = Category.createRootCategory(request.name());
+        } else {
+            Category parent =
+                    categoryRepository
+                            .findById(request.parentId())
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalArgumentException(
+                                                    "Parent category not found: "
+                                                            + request.parentId()));
+            category = Category.createSubCategory(request.name(), parent);
+        }
+
+        return categoryRepository.save(category);
+    }
+
+    // ------------------- 수정 -------------------
+    public CategoryResponse updateCategory(UUID id, String newName) {
+        Category category =
+                categoryRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("Category not found: " + id));
+        category.updateName(newName);
+        return CategoryResponse.fromEntity(category);
+    }
+
+    // ------------------- 삭제 -------------------
+    public void deleteCategory(UUID id) {
+        Category category =
+                categoryRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () -> new IllegalArgumentException("Category not found: " + id));
+        categoryRepository.delete(category);
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
+++ b/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
@@ -4,6 +4,8 @@ import com.irum.come2us.domain.category.domain.entity.Category;
 import com.irum.come2us.domain.category.domain.repository.CategoryRepository;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -19,6 +21,7 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     // ------------------- 전체 조회 -------------------
+    @Transactional(readOnly = true)
     public List<CategoryResponse> findAllCategories() {
         return categoryRepository.findAll().stream()
                 .map(CategoryResponse::fromEntity)
@@ -26,16 +29,18 @@ public class CategoryService {
     }
 
     // ------------------- 단일 조회 -------------------
+    @Transactional(readOnly = true)
     public CategoryResponse getCategoryById(UUID id) {
         Category category =
                 categoryRepository
                         .findById(id)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("Category not found: " + id));
+                                () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
         return CategoryResponse.fromEntity(category);
     }
 
     // ------------------- 트리 조회 -------------------
+    @Transactional(readOnly = true)
     public List<CategoryResponse> findCategoryTree() {
         List<Category> roots = categoryRepository.findByParentIsNull();
         return roots.stream()
@@ -44,7 +49,7 @@ public class CategoryService {
     }
 
     // ------------------- 생성 -------------------
-    public Category create(CategoryCreateRequest request) {
+    public CategoryResponse createCategory(CategoryCreateRequest request) {
         Category category;
 
         if (request.parentId() == null) {
@@ -55,13 +60,13 @@ public class CategoryService {
                             .findById(request.parentId())
                             .orElseThrow(
                                     () ->
-                                            new IllegalArgumentException(
-                                                    "Parent category not found: "
-                                                            + request.parentId()));
+                                            new CommonException(
+                                                    CategoryErrorCode.CATEGORY_NOT_FOUND));
             category = Category.createSubCategory(request.name(), parent);
         }
 
-        return categoryRepository.save(category);
+        Category saved = categoryRepository.save(category);
+        return CategoryResponse.fromEntity(saved);
     }
 
     // ------------------- 수정 -------------------
@@ -70,7 +75,7 @@ public class CategoryService {
                 categoryRepository
                         .findById(id)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("Category not found: " + id));
+                                () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
         category.updateName(newName);
         return CategoryResponse.fromEntity(category);
     }
@@ -81,7 +86,7 @@ public class CategoryService {
                 categoryRepository
                         .findById(id)
                         .orElseThrow(
-                                () -> new IllegalArgumentException("Category not found: " + id));
+                                () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
         categoryRepository.delete(category);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
@@ -1,5 +1,7 @@
 package com.irum.come2us.domain.category.domain.entity;
 
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +16,8 @@ import org.hibernate.annotations.UuidGenerator;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class Category {
+
+    private static final int MAX_DEPTH = 3;
 
     @Id
     @UuidGenerator(style = UuidGenerator.Style.TIME)
@@ -39,8 +43,13 @@ public class Category {
     }
 
     public static Category createSubCategory(String name, Category parent) {
+        if (parent.getDepth() >= MAX_DEPTH) {
+            throw new CommonException(CategoryErrorCode.CATEGORY_DEPTH_EXCEEDED);
+        }
+
         Category child =
                 Category.builder().name(name).parent(parent).depth(parent.getDepth() + 1).build();
+
         parent.addChild(child);
         return child;
     }

--- a/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
@@ -33,7 +33,7 @@ public class Category {
     @Column(name = "depth", nullable = false)
     private int depth;
 
-    // 정적 팩토리 메서드만 public (외부에서 객체 생성 시 사용)
+    // ------------------- 생성 메서드 -------------------
     public static Category createRootCategory(String name) {
         return Category.builder().name(name).depth(1).build();
     }
@@ -41,12 +41,16 @@ public class Category {
     public static Category createSubCategory(String name, Category parent) {
         Category child =
                 Category.builder().name(name).parent(parent).depth(parent.getDepth() + 1).build();
-
         parent.addChild(child);
         return child;
     }
 
     private void addChild(Category child) {
         this.children.add(child);
+    }
+
+    // ------------------- 수정 메서드 -------------------
+    public void updateName(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
@@ -6,6 +6,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
-
     List<Category> findByParentIsNull(); // 루트 카테고리 조회
 }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -1,13 +1,16 @@
 package com.irum.come2us.domain.category.presentation.controller;
 
 import com.irum.come2us.domain.category.application.service.CategoryService;
+import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-// import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/categories")
@@ -16,20 +19,52 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    // 전체 카테고리 조회
+    // ------------------- 전체 조회 -------------------
     @GetMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER','OWNER','MANAGER','MASTER')")
     public ResponseEntity<List<CategoryResponse>> getAllCategories() {
         return ResponseEntity.ok(categoryService.findAllCategories());
     }
 
-    // 카테고리 생성
-    //    @PostMapping
-    //    public ResponseEntity<CategoryResponse> createCategory(
-    //            @RequestBody CategoryCreateRequest request) {
-    //        var category = categoryService.create(request);
-    //        return ResponseEntity.status(HttpStatus.CREATED)
-    //                .body(CategoryResponse.fromEntity(category));
-    //    }
+    // ------------------- 단일 조회 -------------------
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('CUSTOMER','OWNER','MANAGER','MASTER')")
+    public ResponseEntity<CategoryResponse> getCategoryById(@PathVariable UUID id) {
+        CategoryResponse category = categoryService.getCategoryById(id);
+        return ResponseEntity.ok(category);
+    }
 
-    // TODO: exeption 카테고리 도메인 pr 승인 후 재개발
+    // ------------------- 트리 조회 -------------------
+    @GetMapping("/tree")
+    @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
+    public ResponseEntity<List<CategoryResponse>> getCategoryTree() {
+        return ResponseEntity.ok(categoryService.findCategoryTree());
+    }
+
+    // ------------------- 생성 -------------------
+    @PostMapping
+    @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
+    public ResponseEntity<CategoryResponse> createCategory(
+            @RequestBody CategoryCreateRequest request) {
+        var category = categoryService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CategoryResponse.fromEntity(category));
+    }
+
+    // ------------------- 수정 -------------------
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
+    public ResponseEntity<CategoryResponse> updateCategory(
+            @PathVariable UUID id, @RequestBody Map<String, String> request) {
+        CategoryResponse response = categoryService.updateCategory(id, request.get("name"));
+        return ResponseEntity.ok(response);
+    }
+
+    // ------------------- 삭제 -------------------
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<Void> deleteCategory(@PathVariable UUID id) {
+        categoryService.deleteCategory(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -7,9 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,50 +18,38 @@ public class CategoryController {
 
     // ------------------- 전체 조회 -------------------
     @GetMapping
-    @PreAuthorize("hasAnyRole('CUSTOMER','OWNER','MANAGER','MASTER')")
-    public ResponseEntity<List<CategoryResponse>> getAllCategories() {
-        return ResponseEntity.ok(categoryService.findAllCategories());
+    public List<CategoryResponse> getAllCategories() {
+        return categoryService.findAllCategories();
     }
 
     // ------------------- 단일 조회 -------------------
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyRole('CUSTOMER','OWNER','MANAGER','MASTER')")
-    public ResponseEntity<CategoryResponse> getCategoryById(@PathVariable UUID id) {
-        CategoryResponse category = categoryService.getCategoryById(id);
-        return ResponseEntity.ok(category);
+    public CategoryResponse getCategoryById(@PathVariable UUID id) {
+        return categoryService.getCategoryById(id);
     }
 
     // ------------------- 트리 조회 -------------------
     @GetMapping("/tree")
-    @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
-    public ResponseEntity<List<CategoryResponse>> getCategoryTree() {
-        return ResponseEntity.ok(categoryService.findCategoryTree());
+    public List<CategoryResponse> getCategoryTree() {
+        return categoryService.findCategoryTree();
     }
 
     // ------------------- 생성 -------------------
     @PostMapping
-    @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
-    public ResponseEntity<CategoryResponse> createCategory(
-            @RequestBody CategoryCreateRequest request) {
-        var category = categoryService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(CategoryResponse.fromEntity(category));
+    public CategoryResponse createCategory(@RequestBody CategoryCreateRequest request) {
+        return categoryService.createCategory(request);
     }
 
     // ------------------- 수정 -------------------
-    @PutMapping("/{id}")
-    @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
-    public ResponseEntity<CategoryResponse> updateCategory(
+    @PatchMapping("/{id}")
+    public CategoryResponse updateCategory(
             @PathVariable UUID id, @RequestBody Map<String, String> request) {
-        CategoryResponse response = categoryService.updateCategory(id, request.get("name"));
-        return ResponseEntity.ok(response);
+        return categoryService.updateCategory(id, request.get("name"));
     }
 
     // ------------------- 삭제 -------------------
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasRole('MASTER')")
-    public ResponseEntity<Void> deleteCategory(@PathVariable UUID id) {
+    public void deleteCategory(@PathVariable UUID id) {
         categoryService.deleteCategory(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryCreateRequest.java
@@ -1,10 +1,6 @@
 package com.irum.come2us.domain.category.presentation.dto.request;
 
 import java.util.UUID;
-import lombok.Getter;
 
-@Getter
-public class CategoryCreateRequest {
-    private String name;
-    private UUID parentId; // null이면 루트 카테고리
-}
+public record CategoryCreateRequest(String name, UUID parentId // null이면 루트 카테고리
+        ) {}

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryResponse.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryResponse.java
@@ -1,26 +1,35 @@
 package com.irum.come2us.domain.category.presentation.dto.response;
 
 import com.irum.come2us.domain.category.domain.entity.Category;
+import java.util.List;
 import java.util.UUID;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class CategoryResponse {
-
-    private UUID categoryId;
-    private String name;
-    private int depth;
-    private UUID parentId;
-
+public record CategoryResponse(
+        UUID categoryId,
+        String name,
+        int depth,
+        UUID parentId,
+        List<CategoryResponse> children // 트리 조회용
+        ) {
+    // ------------------- 단일 조회용 -------------------
     public static CategoryResponse fromEntity(Category category) {
-        return CategoryResponse.builder()
-                .categoryId(category.getCategoryId())
-                .name(category.getName())
-                .depth(category.getDepth())
-                .parentId(
-                        category.getParent() != null ? category.getParent().getCategoryId() : null)
-                .build();
+        return new CategoryResponse(
+                category.getCategoryId(),
+                category.getName(),
+                category.getDepth(),
+                category.getParent() != null ? category.getParent().getCategoryId() : null,
+                null);
+    }
+
+    // ------------------- 트리 조회용 -------------------
+    public static CategoryResponse fromEntityWithChildren(Category category) {
+        return new CategoryResponse(
+                category.getCategoryId(),
+                category.getName(),
+                category.getDepth(),
+                category.getParent() != null ? category.getParent().getCategoryId() : null,
+                category.getChildren().stream()
+                        .map(CategoryResponse::fromEntityWithChildren)
+                        .toList());
     }
 }

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/CategoryErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/CategoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorCode implements BaseErrorCode {
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 정보를 찾을 수 없습니다."),
+    CATEGORY_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "카테고리 수정에 대한 변경된 내용이 없습니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리입니다."),
+    CATEGORY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "카테고리 최대 깊이(3)를 초과할 수 없습니다."); // depth 제한 에러
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #116

📌 **작업 내용 및 특이사항**

**Category Create** 
카테고리 생성 API (POST /categories)
- 루트/하위 카테고리 구분 생성 (depth 자동 설정)
- Builder private 접근 → createRootCategory(), createSubCategory() 사용
- 권한: MANAGER, MASTER

**Category Read**
- 전체 조회 (GET /categories)
- 단일 조회 (GET /categories/{id})
- 트리 조회 (GET /categories/tree) → fromEntityWithChildren() 확장 가능

**Category Update**
- 이름 수정 (PUT /categories/{id})
- updateName() 사용
- 권한: MANAGER, MASTER

**Category Delete**
- 단일 삭제 (DELETE /categories/{id})
- 하드 삭제 → 추후 soft delete ??
- 권한: MASTER

📚 **추후 예정**
- Soft Delete