### PR TITLE
[Feature] 상품 옵션 그룹 및 옵션 생성 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -179,4 +179,24 @@ public class ProductService {
         productRepository.delete(product);
         log.info("상품 삭제 완료: productId={}", productId);
     }
+
+    public void createOptionGroup(UUID productId, ProductOptionGroupRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        ProductOptionGroup group = ProductOptionGroup.createOptionGroup(product, request.name());
+        product.addOptionGroup(group);
+
+        if (request.optionValues() != null && !request.optionValues().isEmpty()) {
+            for (ProductOptionValueRequest valueReq : request.optionValues()) {
+                ProductOptionValue.createOptionValue(
+                        group, valueReq.name(), valueReq.stockQuantity(), valueReq.extraPrice());
+            }
+        }
+
+        productRepository.save(product);
+        log.info("상품 옵션 그룹 추가 완료: productId={}, groupName={}", productId, request.name());
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -1,11 +1,10 @@
 package com.irum.come2us.domain.product.application.service;
 
 import com.irum.come2us.domain.product.domain.entity.Product;
+import com.irum.come2us.domain.product.domain.entity.ProductOptionGroup;
+import com.irum.come2us.domain.product.domain.entity.ProductOptionValue;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductCursorResponse;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.*;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
@@ -33,6 +32,24 @@ public class ProductService {
                         request.detailDescription(),
                         request.price(),
                         request.isPublic());
+
+        if (request.optionGroups() != null && !request.optionGroups().isEmpty()) {
+            for (ProductOptionGroupRequest groupReq : request.optionGroups()) {
+                ProductOptionGroup group =
+                        ProductOptionGroup.createOptionGroup(product, groupReq.name());
+                product.addOptionGroup(group);
+
+                if (groupReq.optionValues() != null) {
+                    for (ProductOptionValueRequest valueReq : groupReq.optionValues()) {
+                        ProductOptionValue.createOptionValue(
+                                group,
+                                valueReq.name(),
+                                valueReq.stockQuantity(),
+                                valueReq.extraPrice());
+                    }
+                }
+            }
+        }
 
         return ProductResponse.from(productRepository.save(product));
     }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -3,9 +3,12 @@ package com.irum.come2us.domain.product.application.service;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.entity.ProductOptionGroup;
 import com.irum.come2us.domain.product.domain.entity.ProductOptionValue;
+import com.irum.come2us.domain.product.domain.repository.ProductOptionGroupRepository;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.*;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductOptionGroupResponse;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductOptionValueResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
@@ -22,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductOptionGroupRepository optionGroupRepository;
 
     // TODO: 상점 매핑 시, 같은 상점 내 같은 상품 중복 처리
     public ProductResponse createProduct(ProductCreateRequest request) {
@@ -198,5 +202,20 @@ public class ProductService {
 
         productRepository.save(product);
         log.info("상품 옵션 그룹 추가 완료: productId={}, groupName={}", productId, request.name());
+    }
+
+    public void createOptionValue(UUID optionGroupId, ProductOptionValueRequest request) {
+        ProductOptionGroup optionGroup = optionGroupRepository.findById(optionGroupId)
+                .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
+
+        ProductOptionValue.createOptionValue(
+                optionGroup,
+                request.name(),
+                request.stockQuantity(),
+                request.extraPrice() != null ? request.extraPrice() : 0
+        );
+
+        optionGroupRepository.saveAndFlush(optionGroup);
+        log.info("옵션 값 추가 완료: optionGroupId={}, valueName={}", optionGroupId, request.name());
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionValue.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductOptionValue.java
@@ -2,6 +2,7 @@ package com.irum.come2us.domain.product.domain.entity;
 
 import static lombok.AccessLevel.*;
 
+import com.irum.come2us.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -14,11 +15,11 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_product_option_value")
 @SQLDelete(sql = "UPDATE p_product_option_value SET deleted_at = NOW() WHERE option_value_id = ?")
 @Where(clause = "deleted_at IS NULL")
-public class ProductOptionValue {
+public class ProductOptionValue extends BaseEntity {
     @Id
     @UuidGenerator(style = UuidGenerator.Style.TIME)
     @Column(name = "option_value_id", updatable = false, nullable = false)

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductOptionGroupRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductOptionGroupRepository.java
@@ -1,0 +1,9 @@
+package com.irum.come2us.domain.product.domain.repository;
+
+import com.irum.come2us.domain.product.domain.entity.ProductOptionGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProductOptionGroupRepository extends JpaRepository<ProductOptionGroup, UUID> {
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -3,6 +3,8 @@ package com.irum.come2us.domain.product.presentation.controller;
 import com.irum.come2us.domain.product.application.service.ProductService;
 import com.irum.come2us.domain.product.presentation.dto.request.*;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductOptionGroupResponse;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductOptionValueResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -77,6 +79,16 @@ public class ProductController {
             @PathVariable UUID productId, @Valid @RequestBody ProductOptionGroupRequest request) {
         log.info("상품 옵션 그룹 추가 요청: productId={}, groupName={}", productId, request.name());
         productService.createOptionGroup(productId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/options/{optionGroupId}/values")
+    public ResponseEntity<Void> createProductOptionValue(
+            @PathVariable UUID optionGroupId,
+            @Valid @RequestBody ProductOptionValueRequest request
+    ) {
+        log.info("옵션 값 추가 요청: optionGroupId={}, valueName={}", optionGroupId, request.name());
+        productService.createOptionValue(optionGroupId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -1,10 +1,7 @@
 package com.irum.come2us.domain.product.presentation.controller;
 
 import com.irum.come2us.domain.product.application.service.ProductService;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductCursorResponse;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpdateRequest;
-import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
+import com.irum.come2us.domain.product.presentation.dto.request.*;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
 import jakarta.validation.Valid;
@@ -73,5 +70,13 @@ public class ProductController {
         log.info("상품 삭제 요청: productId={}", productId);
         productService.deleteProduct(productId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{productId}/options")
+    public ResponseEntity<Void> createProductOptionGroup(
+            @PathVariable UUID productId, @Valid @RequestBody ProductOptionGroupRequest request) {
+        log.info("상품 옵션 그룹 추가 요청: productId={}, groupName={}", productId, request.name());
+        productService.createOptionGroup(productId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
@@ -3,10 +3,12 @@ package com.irum.come2us.domain.product.presentation.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record ProductCreateRequest(
         @NotBlank(message = "상품명은 필수 입력값입니다.") String name,
         @NotBlank(message = "상품 설명은 필수 입력값입니다.") String description,
         @NotBlank(message = "상품 상세 설명은 필수 입력값입니다.") String detailDescription,
         @NotNull(message = "상품 공개 여부는 필수 입력값입니다.") Boolean isPublic,
-        @Min(value = 0, message = "상품 가격은 0 이상이어야 합니다.") int price) {}
+        @Min(value = 0, message = "상품 가격은 0 이상이어야 합니다.") int price,
+        List<ProductOptionGroupRequest> optionGroups) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductOptionGroupRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductOptionGroupRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record ProductOptionGroupRequest(
+        @NotBlank(message = "옵션 그룹명은 필수 입력값입니다.") String name,
+        List<ProductOptionValueRequest> optionValues) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductOptionValueRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductOptionValueRequest.java
@@ -1,0 +1,10 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductOptionValueRequest(
+        @NotBlank(message = "옵션명은 필수 입력값입니다.") String name,
+        @Min(value = 0, message = "재고 수량은 0 이상이어야 합니다.") int stockQuantity,
+        @NotNull(message = "추가 금액은 필수 입력값입니다.") Integer extraPrice) {}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ProductErrorCode implements BaseErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
     PRODUCT_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "상품 수정에 대한 변경된 내용이 없습니다."),
-    PRODUCT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 상품입니다.");
+    PRODUCT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 상품입니다."),
+    OPTION_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 옵션 그룹을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #122

📌 **작업 내용 및 특이사항**
1. 옵션 생성 관련 DTO 정의
    - `ProductOptionGroupRequest`, `ProductOptionValueRequest`
2. Product 생성 시 OptionGroup과 OptionValue 동시 생성 가능 구현 (`POST /products`)
    - ProductCreateRequest DTO에 OptionGroup 필드 추가
      - null 가능
    - ProductService 수정
      - OptionGroup 값이 있을 경우 생성 -> OptionValue 값이 있을 경우 생성
3. 생성되어 있는 Product에 대해 OptionGroup 생성 구현 (`POST /products/{productId}/options`)
    
4. 생성되어 있는 OptionGroup에 대해 OptionValue 생성 구현 (`POST /products/options/{optionId}/values`)


📚 **참고사항**
