### PR TITLE
[Feature] 상품 상세 조회 시 옵션 조회 기능 추가

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
@@ -1,7 +1,9 @@
 package com.irum.come2us.domain.product.presentation.dto.response;
 
 import com.irum.come2us.domain.product.domain.entity.Product;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * 상품 상세 조회 DTO - 추후 Store, Category, Images, Options 확장 예정
@@ -23,12 +25,11 @@ public record ProductDetailResponse(
         int price,
         boolean isPublic,
         Double avgRating,
-        Integer reviewCount
+        Integer reviewCount,
         // TODO: StoreInfoResponse store,
         // TODO: CategoryInfoResponse category,
         // TODO: List<ImageResponse> images,
-        // TODO: List<OptionGroupResponse> optionGroups
-        ) {
+        List<ProductOptionGroupResponse> optionGroups) {
     public static ProductDetailResponse from(Product product) {
         return new ProductDetailResponse(
                 product.getId(),
@@ -38,6 +39,9 @@ public record ProductDetailResponse(
                 product.getPrice(),
                 product.isPublic(),
                 product.getAvgRating(),
-                product.getReviewCount());
+                product.getReviewCount(),
+                product.getOptionGroups().stream()
+                        .map(ProductOptionGroupResponse::from)
+                        .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductOptionGroupResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductOptionGroupResponse.java
@@ -1,0 +1,18 @@
+package com.irum.come2us.domain.product.presentation.dto.response;
+
+import com.irum.come2us.domain.product.domain.entity.ProductOptionGroup;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public record ProductOptionGroupResponse(
+        UUID id, String name, List<ProductOptionValueResponse> optionValues) {
+    public static ProductOptionGroupResponse from(ProductOptionGroup group) {
+        return new ProductOptionGroupResponse(
+                group.getId(),
+                group.getName(),
+                group.getOptionValues().stream()
+                        .map(ProductOptionValueResponse::from)
+                        .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductOptionValueResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductOptionValueResponse.java
@@ -1,0 +1,12 @@
+package com.irum.come2us.domain.product.presentation.dto.response;
+
+import com.irum.come2us.domain.product.domain.entity.ProductOptionValue;
+import java.util.UUID;
+
+public record ProductOptionValueResponse(
+        UUID id, String name, int stockQuantity, Integer extraPrice) {
+    public static ProductOptionValueResponse from(ProductOptionValue value) {
+        return new ProductOptionValueResponse(
+                value.getId(), value.getName(), value.getStockQuantity(), value.getExtraPrice());
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #147

📌 **작업 내용 및 특이사항**
- `ProductOptionGroupResponse`, `ProductOptionValueResponse` DTO 정의
- 상품 상세 조회 시 (`GET /products/{productId}`) 옵션 확인


📚 **참고사항**
