### PR TITLE
[Feature] 상품-상점 매핑

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -36,25 +36,17 @@ public class ProductService {
     private final StoreRepository storeRepository;
 
     public ProductResponse createProduct(ProductCreateRequest request) {
-        MemberDetails memberDetails =
-                (MemberDetails)
-                        SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        Long memberId = Long.valueOf(memberDetails.getUsername());
-
-        Member member =
-                memberRepository
-                        .findById(memberId)
-                        .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-        if (!member.getRole().equals(Role.OWNER)) {
-            log.warn("상품 등록 실패: 점주 권한이 없는 사용자 memberId={}", member.getMemberId());
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        Member member = getCurrentUser();
 
         Store store =
                 storeRepository
                         .findByMember(member)
                         .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
+
+        if (!member.getRole().equals(Role.OWNER)) {
+            log.warn("상품 등록 실패: 비인가 사용자 memberId={}", member.getMemberId());
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         Product product =
                 Product.createProduct(
@@ -71,10 +63,17 @@ public class ProductService {
     }
 
     public ProductResponse updateProduct(UUID productId, ProductUpdateRequest request) {
+        Member member = getCurrentUser();
+
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getStore().getMember().equals(member)) {
+            log.warn("상품 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         if (request.name() == null
                 && request.description() == null
@@ -130,10 +129,17 @@ public class ProductService {
 
     public ProductResponse updateProductPublicStatus(
             UUID productId, ProductPublicUpdateRequest request) {
+        Member member = getCurrentUser();
+
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getStore().getMember().equals(member) && !member.getRole().equals(Role.MANAGER)) {
+            log.warn("상품 공개 상태 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         boolean newStatus = request.isPublic();
         boolean currentStatus = product.isPublic();
@@ -187,12 +193,36 @@ public class ProductService {
     }
 
     public void deleteProduct(UUID productId) {
+        Member member = getCurrentUser();
+
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
+        if (!product.getStore().getMember().equals(member)) {
+            log.warn("상품 삭제 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
         productRepository.delete(product);
         log.info("상품 삭제 완료: productId={}", productId);
+    }
+
+    private Member getCurrentUser() {
+        var authentication =
+                        SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication.getPrincipal() instanceof MemberDetails details)) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        try {
+            Long memberId = Long.parseLong(details.getUsername());
+            return memberRepository.findById(memberId)
+                    .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+        } catch (NumberFormatException e) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -1,5 +1,8 @@
 package com.irum.come2us.domain.product.application.service;
 
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.entity.enums.Role;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductCreateRequest;
@@ -8,12 +11,19 @@ import com.irum.come2us.domain.product.presentation.dto.request.ProductPublicUpd
 import com.irum.come2us.domain.product.presentation.dto.request.ProductUpdateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductDetailResponse;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductResponse;
+import com.irum.come2us.domain.store.domain.entity.Store;
+import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import java.util.List;
 import java.util.UUID;
+
+import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
+import com.irum.come2us.global.security.MemberDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,18 +33,36 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ProductService {
     private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
 
-    // TODO: 상점 매핑 시, 같은 상점 내 같은 상품 중복 처리
     public ProductResponse createProduct(ProductCreateRequest request) {
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long memberId = Long.valueOf(memberDetails.getUsername());
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!member.getRole().equals(Role.OWNER)) {
+            log.warn("상품 등록 실패: 점주 권한이 없는 사용자 memberId={}", member.getMemberId());
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        Store store = storeRepository.findByMember(member)
+                .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
+
         Product product =
                 Product.createProduct(
+                        store,
                         request.name(),
                         request.description(),
                         request.detailDescription(),
                         request.price(),
                         request.isPublic());
 
-        return ProductResponse.from(productRepository.save(product));
+        productRepository.save(product);
+        log.info("상품 등록 완료: storeId={}, productName={}", store.getId(), product.getName());
+        return ProductResponse.from(product);
     }
 
     public ProductResponse updateProduct(UUID productId, ProductUpdateRequest request) {

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -71,7 +71,10 @@ public class ProductService {
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         if (!product.getStore().getMember().equals(member)) {
-            log.warn("상품 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+            log.warn(
+                    "상품 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
+                    member.getMemberId(),
+                    product.getStore().getMember().getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
@@ -136,8 +139,12 @@ public class ProductService {
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member) && !member.getRole().equals(Role.MANAGER)) {
-            log.warn("상품 공개 상태 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+        if (!product.getStore().getMember().equals(member)
+                && !member.getRole().equals(Role.MANAGER)) {
+            log.warn(
+                    "상품 공개 상태 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
+                    member.getMemberId(),
+                    product.getStore().getMember().getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
@@ -201,7 +208,10 @@ public class ProductService {
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         if (!product.getStore().getMember().equals(member)) {
-            log.warn("상품 삭제 실패: 비인가 사용자 memberId={}, storeOwnerId={}", member.getMemberId(), product.getStore().getMember().getMemberId());
+            log.warn(
+                    "상품 삭제 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
+                    member.getMemberId(),
+                    product.getStore().getMember().getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
@@ -210,16 +220,17 @@ public class ProductService {
     }
 
     private Member getCurrentUser() {
-        var authentication =
-                        SecurityContextHolder.getContext().getAuthentication();
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || !(authentication.getPrincipal() instanceof MemberDetails details)) {
+        if (authentication == null
+                || !(authentication.getPrincipal() instanceof MemberDetails details)) {
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         try {
             Long memberId = Long.parseLong(details.getUsername());
-            return memberRepository.findById(memberId)
+            return memberRepository
+                    .findById(memberId)
                     .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
         } catch (NumberFormatException e) {
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -16,11 +16,10 @@ import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
-import java.util.List;
-import java.util.UUID;
-
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
 import com.irum.come2us.global.security.MemberDetails;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,19 +36,25 @@ public class ProductService {
     private final StoreRepository storeRepository;
 
     public ProductResponse createProduct(ProductCreateRequest request) {
-        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberDetails memberDetails =
+                (MemberDetails)
+                        SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long memberId = Long.valueOf(memberDetails.getUsername());
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member =
+                memberRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (!member.getRole().equals(Role.OWNER)) {
             log.warn("상품 등록 실패: 점주 권한이 없는 사용자 memberId={}", member.getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        Store store = storeRepository.findByMember(member)
-                .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
+        Store store =
+                storeRepository
+                        .findByMember(member)
+                        .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
 
         Product product =
                 Product.createProduct(

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -1,5 +1,6 @@
 package com.irum.come2us.domain.product.domain.entity;
 
+import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -49,13 +50,19 @@ public class Product extends BaseEntity {
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductOptionGroup> optionGroups = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Product(
+            Store store,
             String name,
             String description,
             boolean isPublic,
             String detailDescription,
             int price) {
+        this.store = store;
         this.name = name;
         this.description = description;
         this.isPublic = isPublic;
@@ -64,12 +71,14 @@ public class Product extends BaseEntity {
     }
 
     public static Product createProduct(
+            Store store,
             String name,
             String description,
             String detailDescription,
             int price,
             boolean isPublic) {
         return Product.builder()
+                .store(store)
                 .name(name)
                 .description(description)
                 .detailDescription(detailDescription)
@@ -100,5 +109,5 @@ public class Product extends BaseEntity {
         optionGroups.add(group);
     }
 
-    // TODO: Store, Category, 이미지 매핑
+    // TODO: Category, 이미지 매핑
 }

--- a/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/irum/come2us/domain/store/domain/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.irum.come2us.domain.store.domain.repository;
 
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.store.domain.entity.Store;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
     boolean existsByBusinessRegistrationNumber(String businessRegistrationNumber);
 
     boolean existsByTelemarketingRegistrationNumber(String telemarketingRegistrationNumber);
+
+    Optional<Store> findByMember(Member member);
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #149 

## 📌 **작업 내용 및 특이사항**
### Product Entity
- Store-Product 1:N 관계 (`ManyToOne`)
- Product가 Store에 종속
- `createProduct` 정적 팩토리 메서드 재정의 (`store` 추가)

### ProductService
- 생성 / 수정 / 삭제에 대해 접근 제어 설정:
  - 사용자의 역할이 `OWNER`인지 판별 (생성, 수정, 상태 수정, 삭제)
  - 사용자의 상점 내의 상품인지 판별 (수정, 상태 수정, 삭제)
  - 사용자의 역할이 `MANAGER`인지 판별 (상태 수정)


## 📚 **참고사항**
ProductService에 구현한 `getCurrentUser()`는 선우님께서 Util 생성하시면 변경하도록 하겠습니다.