### PR TITLE
[Feature] Member Util 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/irum/come2us/domain/auth/application/service/AuthService.java
@@ -6,6 +6,7 @@ import com.irum.come2us.domain.auth.presentation.dto.response.MemberLoginRespons
 import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.global.util.CookieUtil;
+import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ public class AuthService {
     private final JwtTokenService jwtTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final CookieUtil cookieUtil;
+    private final MemberUtil memberUtil;
 
     public MemberLoginResponse processMemberLogin(MemberLoginRequest request) {
         Member member = memberValidator.getMemberByEmail(request.email());
@@ -31,7 +33,7 @@ public class AuthService {
     }
 
     public HttpHeaders processMemberLogout() {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         refreshTokenRepository.deleteById(member.getMemberId());
         return cookieUtil.deleteRefreshTokenCookie();
     }

--- a/src/main/java/com/irum/come2us/domain/deliveryaddress/application/service/DeliveryAddressService.java
+++ b/src/main/java/com/irum/come2us/domain/deliveryaddress/application/service/DeliveryAddressService.java
@@ -11,7 +11,7 @@ import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.DeliveryAddressErrorCode;
-import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.util.MemberUtil;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class DeliveryAddressService {
     private final MemberValidator memberValidator;
+    private final MemberUtil memberUtil;
     private final DeliveryAddressRepository deliveryAddressRepository;
 
     public void createDeliveryAddress(DeliveryAddressRegisterRequest request) {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         String recipientName =
                 request.recipientName() == null ? member.getName() : request.recipientName();
         String recipientContact =
@@ -55,7 +56,7 @@ public class DeliveryAddressService {
         int limit = pageSize + 1;
         List<DeliveryAddressInfoResponse> addressList =
                 deliveryAddressRepository.findDeliveryAddressByCursor(
-                        memberValidator.getCurrentMember().getMemberId(), cursor, limit);
+                        memberUtil.getCurrentMember().getMemberId(), cursor, limit);
         boolean hasNext = addressList.size() > pageSize;
         List<DeliveryAddressInfoResponse> resultList =
                 hasNext ? addressList.subList(0, pageSize) : addressList;
@@ -85,7 +86,7 @@ public class DeliveryAddressService {
     }
 
     public void removeDeliveryAddress(UUID deliveryAddressId) {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         DeliveryAddress address = validDeliveryAddress(deliveryAddressId);
         if (address.isDefault()) {
             // DeliveryAddress 중 가장 최근 것 기본 배송지 설정
@@ -105,13 +106,12 @@ public class DeliveryAddressService {
                                         new CommonException(
                                                 DeliveryAddressErrorCode
                                                         .DELIVERY_ADDRESS_NOT_FOUND));
-        if (!address.getMember().equals(memberValidator.getCurrentMember()))
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        memberUtil.assertMemberResourceAccess(address.getMember());
         return address;
     }
 
     private DeliveryAddress getCurrentDefaultAddress() {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         return deliveryAddressRepository
                 .findDefaultAddressByMember(member)
                 .orElseThrow(

--- a/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/service/MemberService.java
@@ -7,6 +7,7 @@ import com.irum.come2us.domain.member.presentation.dto.request.MemberCreateReque
 import com.irum.come2us.domain.member.presentation.dto.request.MemberInfoUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.request.MemberPasswordUpdateRequest;
 import com.irum.come2us.domain.member.presentation.dto.response.MemberInfoResponse;
+import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberValidator memberValidator;
+    private final MemberUtil memberUtil;
     private final BCryptPasswordEncoder passwordEncoder;
 
     public void createCustomer(MemberCreateRequest request) {
@@ -42,30 +44,30 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberInfoResponse findMemberInfo() {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         return MemberInfoResponse.createMemberInfoResponse(member);
     }
 
     public void changeMemberNameAndContact(MemberInfoUpdateRequest request) {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         member.updateName(request.name());
         member.updateContact(request.contact());
     }
 
     public void changeMemberPassword(MemberPasswordUpdateRequest request) {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         memberValidator.validatePassword(request.originalPassword(), request.newPassword(), member);
         member.updatePassword(passwordEncoder.encode(request.newPassword()));
     } // 추후 BCryptEncoder 사용한 암/복호화 검증 로직 적용 예정
 
     public void changeCustomerRoleToOwner() {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         memberValidator.assertMemberIsNotOwner(member);
         member.grantOwner();
     }
 
     public void withdrawCustomer() {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         memberValidator.assertMemberIsCustomer(member);
         memberRepository.delete(member);
     }

--- a/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
+++ b/src/main/java/com/irum/come2us/domain/member/application/util/MemberValidator.java
@@ -20,12 +20,16 @@ public class MemberValidator {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    /** MemberUtil 구현된 메서드 사용(25.10.23~) * */
+    @Deprecated
     public Member getCurrentMember() {
         return memberRepository
                 .findByMemberId(getCurrentMemberId())
                 .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-    } // 로그인 된 유저 정보 조회
+    }
 
+    /** MemberUtil 구현된 메서드 사용(25.10.23~) * */
+    @Deprecated
     private Long getCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getPrincipal() == null) {

--- a/src/main/java/com/irum/come2us/global/util/MemberUtil.java
+++ b/src/main/java/com/irum/come2us/global/util/MemberUtil.java
@@ -1,0 +1,45 @@
+package com.irum.come2us.global.util;
+
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.AuthErrorCode;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.security.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findByMemberId(getCurrentMemberId())
+                .orElseThrow(() -> new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND));
+    } // 로그인 된 유저 정보 조회
+
+    public void assertMemberResourceAccess(Member member) {
+        if (!member.getMemberId().equals(getCurrentMember().getMemberId()))
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    private Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+        try {
+            MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+            return Long.parseLong(memberDetails.getUsername());
+        } catch (ClassCastException e) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        } catch (Exception e) {
+            throw new CommonException(AuthErrorCode.AUTHENTICATION_NOT_FOUND);
+        }
+    } // 로그인 된 아이디 반환
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #157

- 현재 인증된 Member 정보 조회 및 검증을 위한 MemberUtil 유틸리티 컴포넌트 구현

📌 **작업 내용 및 특이사항**


## getCurrentMember()
- 현재 로그인된 사용자 정보를 MemberRepository에서 조회
-  조회 실패 시 401 `AUTHENTICATION_NOT_FOUND` 에러 처리

### 사용 예

```java
@Transactional(readOnly = true)
    public MemberInfoResponse findMemberInfo() {
        Member member = memberUtil.getCurrentMember();
        return MemberInfoResponse.createMemberInfoResponse(member);
    }

```


## assertMemberResourceAccess()
- 리소스에 Member와 현재 로그인된 멤버 정보 비교 -> 리소스 조회/수정/삭제 가능한 사용자인지 검증
- 검증 실패 시 403 `UNAUTHORIZED_ACCESS` 에러 처리

### 사용 예

```java
private DeliveryAddress validDeliveryAddress(UUID deliveryAddressId) {
        DeliveryAddress address =
                deliveryAddressRepository
                        .findById(deliveryAddressId)
                        .orElseThrow(
                                () ->
                                        new CommonException(
                                                DeliveryAddressErrorCode
                                                        .DELIVERY_ADDRESS_NOT_FOUND));
        memberUtil.assertMemberResourceAccess(address.getMember());
        return address;
    }
```

## getCurrentMemberId()
-  로그인 후 SecurityContextHolder에 저장된 MemberDetails 인증 정보로부터 Member 아이디를 반환하는 MemberUtil 내부 메서드
- **타 도메인에서 직접 접근 X**
- Member의 Id가 필요할 때는  다음과 같이 사용

```java
Member member = memberUtil.getCurrentMember().getMemberId()
```



📚 **참고사항**
- @isak-kang 코드 충돌 방지를 위해, 현재 Store 도메인 서비스단에 적용된 기존 MemberValidator 클래스 메서드는 수정하지 않았으니, 추후 확인하여 수정 바랍니다.
- Store 도메인 및 기존 로직 사용된 코드 리팩토링 완료되면 MemberValidator 내 메서드 삭제 예정