### PR TITLE
[Feature] 상품 옵션 그룹 및 값 삭제 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -276,7 +276,8 @@ public class ProductService {
         ProductOptionGroup optionGroup =
                 optionGroupRepository
                         .findById(optionGroupId)
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
+                        .orElseThrow(
+                                () -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
 
         optionGroupRepository.delete(optionGroup);
         log.info("상품 옵션 그룹 삭제 완료: groupId={}", optionGroupId);
@@ -286,7 +287,8 @@ public class ProductService {
         ProductOptionValue optionValue =
                 optionValueRepository
                         .findById(optionValueId)
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
+                        .orElseThrow(
+                                () -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
 
         optionValueRepository.delete(optionValue);
         log.info("상품 옵션 값 삭제 완료: valueId={}", optionValueId);

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -279,6 +279,16 @@ public class ProductService {
                         .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
 
         optionGroupRepository.delete(optionGroup);
-        log.info("상품 옵션 그룹 완료: groupId={}", optionGroupId);
+        log.info("상품 옵션 그룹 삭제 완료: groupId={}", optionGroupId);
+    }
+
+    public void deleteProductOptionValue(UUID optionValueId) {
+        ProductOptionValue optionValue =
+                optionValueRepository
+                        .findById(optionValueId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
+
+        optionValueRepository.delete(optionValue);
+        log.info("상품 옵션 값 삭제 완료: valueId={}", optionValueId);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -271,4 +271,14 @@ public class ProductService {
 
         return ProductOptionValueResponse.from(optionValue);
     }
+
+    public void deleteProductOptionGroup(UUID optionGroupId) {
+        ProductOptionGroup optionGroup =
+                optionGroupRepository
+                        .findById(optionGroupId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
+
+        optionGroupRepository.delete(optionGroup);
+        log.info("상품 옵션 그룹 완료: groupId={}", optionGroupId);
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -110,4 +110,13 @@ public class ProductController {
                 productService.updateProductOptionValue(optionValueId, request);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/options/{optionGroupId}")
+    public ResponseEntity<Void> deleteProductOptionGroup(
+            @PathVariable UUID optionGroupId){
+        log.info("상품 옵션 그룹 삭제 요청: groupId={}", optionGroupId);
+        productService.deleteProductOptionGroup(optionGroupId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -119,4 +119,12 @@ public class ProductController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/options/values/{optionValueId}")
+    public ResponseEntity<Void> deleteProductOptionValue(
+            @PathVariable UUID optionValueId) {
+        log.info("상품 옵션 값 삭제 요청: valueId={}", optionValueId);
+        productService.deleteProductOptionValue(optionValueId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -112,17 +112,14 @@ public class ProductController {
     }
 
     @DeleteMapping("/options/{optionGroupId}")
-    public ResponseEntity<Void> deleteProductOptionGroup(
-            @PathVariable UUID optionGroupId){
+    public ResponseEntity<Void> deleteProductOptionGroup(@PathVariable UUID optionGroupId) {
         log.info("상품 옵션 그룹 삭제 요청: groupId={}", optionGroupId);
         productService.deleteProductOptionGroup(optionGroupId);
-
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/options/values/{optionValueId}")
-    public ResponseEntity<Void> deleteProductOptionValue(
-            @PathVariable UUID optionValueId) {
+    public ResponseEntity<Void> deleteProductOptionValue(@PathVariable UUID optionValueId) {
         log.info("상품 옵션 값 삭제 요청: valueId={}", optionValueId);
         productService.deleteProductOptionValue(optionValueId);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #126 

📌 **작업 내용 및 특이사항**
- 상품 옵션 그룹 및 옵션 값 삭제 API 구현
  - `DELETE /products/options/{optionGroupId}` : 옵션 그룹 Soft Delete
  - `DELETE /products/options/values/{optionValueId}` : 옵션 값 Soft Delete
- 옵션 그룹 삭제 시, 하위 옵션 값 함께 삭제

📚 **참고사항**
- `ResponseEntity` 는 일단 다른 코드들과 일관되게 작성하기 위해 사용하여 코드 작성했습니다.
- Store 접근 제어 로직은 Product-Store 매핑 머지 후 추가 예정
- 현재 장바구니나 주문 등이 옵션 값과 연결되어 있는데, 옵션 값이 삭제되더라도 같이 삭제되지 않도록 주의해주시기 바랍니다.
  - 추가로 옵션이 삭제되어도 결제나 주문 조회에서는 해당 상품에 대한 조회가 이뤄질 수 있도록 쿼리 작성해도 좋을 거 같습니다.