### PR TITLE
[Feature] ProductImage CRUD 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
@@ -8,8 +8,8 @@ import com.irum.come2us.domain.product.domain.repository.ProductRepository;
 import com.irum.come2us.domain.product.presentation.dto.request.ProductImageCreateRequest;
 import com.irum.come2us.domain.product.presentation.dto.response.ProductImageResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
-import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductImageErrorCode;
 import com.irum.come2us.global.util.MemberUtil;
 import java.util.List;
 import java.util.UUID;
@@ -30,53 +30,67 @@ public class ProductImageService {
 
     public ProductImageResponse addImage(UUID productId, ProductImageCreateRequest request) {
         Member member = memberUtil.getCurrentMember();
-        Product product =
-                productRepository
-                        .findById(productId)
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
+        // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(product.getStore().getMember());
+
+        // 대표 이미지 중복 등록 방지
+        if (request.isDefault()) {
+            boolean alreadyHasDefault = productImageRepository.findByProductId(productId)
+                    .stream()
+                    .anyMatch(ProductImage::isDefault);
+            if (alreadyHasDefault) {
+                throw new CommonException(ProductImageErrorCode.DUPLICATE_DEFAULT_IMAGE);
+            }
+        }
 
         ProductImage image = ProductImage.create(product, request.imageUrl(), request.isDefault());
         productImageRepository.save(image);
-        log.info("상품 이미지 추가: productId={}, imageUrl={}", productId, request.imageUrl());
 
-        if (request.isDefault()) {
-            productImageRepository.findByProductId(productId).stream()
-                    .filter(img -> !img.getId().equals(image.getId()) && img.isDefault())
-                    .forEach(img -> img.update(img.getImageUrl(), false));
-        }
+        log.info("상품 이미지 추가 완료: productId={}, imageUrl={}, isDefault={}",
+                productId, request.imageUrl(), request.isDefault());
 
         return ProductImageResponse.from(image);
     }
 
     public void deleteImage(UUID productId, UUID imageId) {
         Member member = memberUtil.getCurrentMember();
-        ProductImage image =
-                productImageRepository
-                        .findById(imageId)
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        ProductImage image = productImageRepository.findById(imageId)
+                .orElseThrow(() -> new CommonException(ProductImageErrorCode.PRODUCT_IMAGE_NOT_FOUND));
 
+        // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(image.getProduct().getStore().getMember());
 
+        // 요청한 productId와 이미지가 속한 product 불일치 시 → 잘못된 요청
         if (!image.getProduct().getId().equals(productId)) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+            throw new CommonException(ProductImageErrorCode.INVALID_PRODUCT_IMAGE_RELATION);
         }
 
-        productImageRepository.delete(image);
-        log.info("상품 이미지 삭제 완료: imageId={}, productId={}", imageId, productId);
+        try {
+            productImageRepository.delete(image);
+            log.info("상품 이미지 삭제 완료: imageId={}, productId={}", imageId, productId);
+        } catch (Exception e) {
+            throw new CommonException(ProductImageErrorCode.IMAGE_DELETE_FAILED);
+        }
     }
 
     public void setDefaultImage(UUID productId, UUID imageId) {
         Member member = memberUtil.getCurrentMember();
-        Product product =
-                productRepository
-                        .findById(productId)
-                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
+        // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         List<ProductImage> images = productImageRepository.findByProductId(productId);
+
+        boolean imageExists = images.stream().anyMatch(img -> img.getId().equals(imageId));
+        if (!imageExists) {
+            throw new CommonException(ProductImageErrorCode.INVALID_PRODUCT_IMAGE_RELATION);
+        }
+
         images.forEach(img -> img.update(img.getImageUrl(), img.getId().equals(imageId)));
 
         log.info("대표 이미지 변경 완료: productId={}, newDefaultImageId={}", productId, imageId);
@@ -85,6 +99,9 @@ public class ProductImageService {
     @Transactional(readOnly = true)
     public List<ProductImageResponse> getImages(UUID productId) {
         List<ProductImage> images = productImageRepository.findByProductId(productId);
+        if (images.isEmpty()) {
+            throw new CommonException(ProductImageErrorCode.PRODUCT_IMAGE_NOT_FOUND);
+        }
         return images.stream().map(ProductImageResponse::from).toList();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
@@ -1,7 +1,6 @@
 package com.irum.come2us.domain.product.application.service;
 
 import com.irum.come2us.domain.member.domain.entity.Member;
-import com.irum.come2us.domain.member.domain.repository.MemberRepository;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.entity.ProductImage;
 import com.irum.come2us.domain.product.domain.repository.ProductImageRepository;
@@ -11,12 +10,11 @@ import com.irum.come2us.domain.product.presentation.dto.response.ProductImageRes
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
-import com.irum.come2us.global.security.MemberDetails;
+import com.irum.come2us.global.util.MemberUtil;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,24 +26,21 @@ public class ProductImageService {
 
     private final ProductImageRepository productImageRepository;
     private final ProductRepository productRepository;
-    private final MemberRepository memberRepository;
+    private final MemberUtil memberUtil;
 
     public ProductImageResponse addImage(UUID productId, ProductImageCreateRequest request) {
-        Member member = getCurrentUser();
+        Member member = memberUtil.getCurrentMember();
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member)) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         ProductImage image = ProductImage.create(product, request.imageUrl(), request.isDefault());
         productImageRepository.save(image);
         log.info("상품 이미지 추가: productId={}, imageUrl={}", productId, request.imageUrl());
 
-        // 대표 이미지 중복 방지
         if (request.isDefault()) {
             productImageRepository.findByProductId(productId).stream()
                     .filter(img -> !img.getId().equals(image.getId()) && img.isDefault())
@@ -56,31 +51,30 @@ public class ProductImageService {
     }
 
     public void deleteImage(UUID productId, UUID imageId) {
-        Member member = getCurrentUser();
+        Member member = memberUtil.getCurrentMember();
         ProductImage image =
                 productImageRepository
                         .findById(imageId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!image.getProduct().getId().equals(productId)
-                || !image.getProduct().getStore().getMember().equals(member)) {
+        memberUtil.assertMemberResourceAccess(image.getProduct().getStore().getMember());
+
+        if (!image.getProduct().getId().equals(productId)) {
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         productImageRepository.delete(image);
-        log.info("상품 이미지 삭제: imageId={}, productId={}", imageId, productId);
+        log.info("상품 이미지 삭제 완료: imageId={}, productId={}", imageId, productId);
     }
 
     public void setDefaultImage(UUID productId, UUID imageId) {
-        Member member = getCurrentUser();
+        Member member = memberUtil.getCurrentMember();
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member)) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         List<ProductImage> images = productImageRepository.findByProductId(productId);
         images.forEach(img -> img.update(img.getImageUrl(), img.getId().equals(imageId)));
@@ -92,21 +86,5 @@ public class ProductImageService {
     public List<ProductImageResponse> getImages(UUID productId) {
         List<ProductImage> images = productImageRepository.findByProductId(productId);
         return images.stream().map(ProductImageResponse::from).toList();
-    }
-
-    private Member getCurrentUser() {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null
-                || !(authentication.getPrincipal() instanceof MemberDetails details)) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        try {
-            Long memberId = Long.parseLong(details.getUsername());
-            return memberRepository
-                    .findById(memberId)
-                    .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-        } catch (NumberFormatException e) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
@@ -30,17 +30,19 @@ public class ProductImageService {
 
     public ProductImageResponse addImage(UUID productId, ProductImageCreateRequest request) {
         Member member = memberUtil.getCurrentMember();
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         // 대표 이미지 중복 등록 방지
         if (request.isDefault()) {
-            boolean alreadyHasDefault = productImageRepository.findByProductId(productId)
-                    .stream()
-                    .anyMatch(ProductImage::isDefault);
+            boolean alreadyHasDefault =
+                    productImageRepository.findByProductId(productId).stream()
+                            .anyMatch(ProductImage::isDefault);
             if (alreadyHasDefault) {
                 throw new CommonException(ProductImageErrorCode.DUPLICATE_DEFAULT_IMAGE);
             }
@@ -49,16 +51,24 @@ public class ProductImageService {
         ProductImage image = ProductImage.create(product, request.imageUrl(), request.isDefault());
         productImageRepository.save(image);
 
-        log.info("상품 이미지 추가 완료: productId={}, imageUrl={}, isDefault={}",
-                productId, request.imageUrl(), request.isDefault());
+        log.info(
+                "상품 이미지 추가 완료: productId={}, imageUrl={}, isDefault={}",
+                productId,
+                request.imageUrl(),
+                request.isDefault());
 
         return ProductImageResponse.from(image);
     }
 
     public void deleteImage(UUID productId, UUID imageId) {
         Member member = memberUtil.getCurrentMember();
-        ProductImage image = productImageRepository.findById(imageId)
-                .orElseThrow(() -> new CommonException(ProductImageErrorCode.PRODUCT_IMAGE_NOT_FOUND));
+        ProductImage image =
+                productImageRepository
+                        .findById(imageId)
+                        .orElseThrow(
+                                () ->
+                                        new CommonException(
+                                                ProductImageErrorCode.PRODUCT_IMAGE_NOT_FOUND));
 
         // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(image.getProduct().getStore().getMember());
@@ -78,8 +88,10 @@ public class ProductImageService {
 
     public void setDefaultImage(UUID productId, UUID imageId) {
         Member member = memberUtil.getCurrentMember();
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         // 상품 소유자 검증
         memberUtil.assertMemberResourceAccess(product.getStore().getMember());

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
@@ -1,0 +1,112 @@
+package com.irum.come2us.domain.product.application.service;
+
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.member.domain.repository.MemberRepository;
+import com.irum.come2us.domain.product.domain.entity.Product;
+import com.irum.come2us.domain.product.domain.entity.ProductImage;
+import com.irum.come2us.domain.product.domain.repository.ProductImageRepository;
+import com.irum.come2us.domain.product.domain.repository.ProductRepository;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductImageCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductImageResponse;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
+import com.irum.come2us.global.security.MemberDetails;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ProductImageService {
+
+    private final ProductImageRepository productImageRepository;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+
+    public ProductImageResponse addImage(UUID productId, ProductImageCreateRequest request) {
+        Member member = getCurrentUser();
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getStore().getMember().equals(member)) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        ProductImage image = ProductImage.create(product, request.imageUrl(), request.isDefault());
+        productImageRepository.save(image);
+        log.info("상품 이미지 추가: productId={}, imageUrl={}", productId, request.imageUrl());
+
+        // 대표 이미지 중복 방지
+        if (request.isDefault()) {
+            productImageRepository.findByProductId(productId).stream()
+                    .filter(img -> !img.getId().equals(image.getId()) && img.isDefault())
+                    .forEach(img -> img.update(img.getImageUrl(), false));
+        }
+
+        return ProductImageResponse.from(image);
+    }
+
+    public void deleteImage(UUID productId, UUID imageId) {
+        Member member = getCurrentUser();
+        ProductImage image =
+                productImageRepository
+                        .findById(imageId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!image.getProduct().getId().equals(productId)
+                || !image.getProduct().getStore().getMember().equals(member)) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        productImageRepository.delete(image);
+        log.info("상품 이미지 삭제: imageId={}, productId={}", imageId, productId);
+    }
+
+    public void setDefaultImage(UUID productId, UUID imageId) {
+        Member member = getCurrentUser();
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getStore().getMember().equals(member)) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        List<ProductImage> images = productImageRepository.findByProductId(productId);
+        images.forEach(img -> img.update(img.getImageUrl(), img.getId().equals(imageId)));
+
+        log.info("대표 이미지 변경 완료: productId={}, newDefaultImageId={}", productId, imageId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductImageResponse> getImages(UUID productId) {
+        List<ProductImage> images = productImageRepository.findByProductId(productId);
+        return images.stream().map(ProductImageResponse::from).toList();
+    }
+
+    private Member getCurrentUser() {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || !(authentication.getPrincipal() instanceof MemberDetails details)) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+        try {
+            Long memberId = Long.parseLong(details.getUsername());
+            return memberRepository
+                    .findById(memberId)
+                    .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
+        } catch (NumberFormatException e) {
+            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductImageRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductImageRepository.java
@@ -1,0 +1,13 @@
+package com.irum.come2us.domain.product.domain.repository;
+
+import com.irum.come2us.domain.product.domain.entity.ProductImage;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductImageRepository extends JpaRepository<ProductImage, UUID> {
+
+    List<ProductImage> findByProductId(UUID productId);
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductImageController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductImageController.java
@@ -1,0 +1,38 @@
+package com.irum.come2us.domain.product.presentation.controller;
+
+import com.irum.come2us.domain.product.application.service.ProductImageService;
+import com.irum.come2us.domain.product.presentation.dto.request.ProductImageCreateRequest;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductImageResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/products/{productId}/images")
+@RequiredArgsConstructor
+public class ProductImageController {
+
+    private final ProductImageService productImageService;
+
+    @PostMapping
+    public ProductImageResponse addImage(
+            @PathVariable UUID productId, @RequestBody ProductImageCreateRequest request) {
+        return productImageService.addImage(productId, request);
+    }
+
+    @DeleteMapping("/{imageId}")
+    public void deleteImage(@PathVariable UUID productId, @PathVariable UUID imageId) {
+        productImageService.deleteImage(productId, imageId);
+    }
+
+    @PatchMapping("/{imageId}/default")
+    public void setDefaultImage(@PathVariable UUID productId, @PathVariable UUID imageId) {
+        productImageService.setDefaultImage(productId, imageId);
+    }
+
+    @GetMapping
+    public List<ProductImageResponse> getImages(@PathVariable UUID productId) {
+        return productImageService.getImages(productId);
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductImageCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductImageCreateRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductImageCreateRequest(
+        @NotBlank(message = "이미지 URL은 필수 입력값입니다.") String imageUrl,
+        @NotNull(message = "대표 여부는 필수 입력값입니다.") Boolean isDefault) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductImageResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductImageResponse.java
@@ -1,0 +1,10 @@
+package com.irum.come2us.domain.product.presentation.dto.response;
+
+import com.irum.come2us.domain.product.domain.entity.ProductImage;
+import java.util.UUID;
+
+public record ProductImageResponse(UUID id, String imageUrl, boolean isDefault) {
+    public static ProductImageResponse from(ProductImage entity) {
+        return new ProductImageResponse(entity.getId(), entity.getImageUrl(), entity.isDefault());
+    }
+}

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductImageErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductImageErrorCode.java
@@ -7,7 +7,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ProductImageErrorCode implements BaseErrorCode {
-
     PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 이미지를 찾을 수 없습니다."),
     INVALID_PRODUCT_IMAGE_RELATION(HttpStatus.BAD_REQUEST, "요청한 상품과 이미지가 일치하지 않습니다."),
     DUPLICATE_DEFAULT_IMAGE(HttpStatus.CONFLICT, "이미 대표 이미지가 존재합니다."),

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductImageErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/ProductImageErrorCode.java
@@ -1,0 +1,24 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ProductImageErrorCode implements BaseErrorCode {
+
+    PRODUCT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 이미지를 찾을 수 없습니다."),
+    INVALID_PRODUCT_IMAGE_RELATION(HttpStatus.BAD_REQUEST, "요청한 상품과 이미지가 일치하지 않습니다."),
+    DUPLICATE_DEFAULT_IMAGE(HttpStatus.CONFLICT, "이미 대표 이미지가 존재합니다."),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다."),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #178 

## 📌 **작업 내용 및 특이사항**
### 상품 이미지 CRUD 구현
(상품 이미지 등록 / 상품 이미지 조회 / 대표 이미지 변경 / 상품 이미지 삭제)

`ProductImageService` 분리 및 `ProductImageController` 신규 생성

`MemberUtil` 기반 인증·권한 검증 로직 통합

### 공통

인증된 사용자 조회 및 소유권 검증 로직 `MemberUtil` 활용

모든 이미지 관련 작업 시 `MemberUtil.assertMemberResourceAccess()` 적용

Product ↔ ProductImage 간 양방향 연관관계 설정
(ProductImage가 FK 보유, Product는 `mappedBy = "product"`로 역방향 매핑)

Soft Delete 적용 (`@SQLDelete`, `@Where`)

공통 응답 규격 `CommonResponse` 자동 래핑 (via `CommonResponseAdvice`)

### 상품 이미지 등록

`POST /products/{productId}/images`

상품별 이미지 추가 기능 구현

대표 이미지(`isDefault`) 지정 시 기존 대표 이미지 자동 해제 로직 추가

비즈니스 로직:
```java
if (request.isDefault()) {
    productImageRepository.findByProductId(productId)
        .stream()
        .filter(img -> !img.getId().equals(image.getId()) && img.isDefault())
        .forEach(img -> img.update(img.getImageUrl(), false));
}
```
### 상품 이미지 조회

`GET /products/{productId}/images`

특정 상품의 모든 이미지 목록 반환

추후 `ProductDetailResponse`에 대표 이미지 리스트로 통합 예정

### 대표 이미지 변경

`PATCH /products/{productId}/images/{imageId}/default`

상품당 대표 이미지는 1개만 유지되도록 구현

### 상품 이미지 삭제

`DELETE /products/{productId}/images/{imageId}`

소유자 검증 후 soft delete 수행

## 📚 참고사항

`ProductImage` 엔티티는 Soft Delete 처리되어 DB에 물리 삭제되지 않음

향후 `CartResponse`, `ProductDetailResponse` 등에서 대표 이미지 URL 노출 예정

권한 검증 로직은 `MemberUtil`을 기준으로 서비스 전반에 통일 예정

별도의 Image Upload API (S3 업로드 등) 연동은 추후 단계에서 구현 예정


## 📚 **참고사항**

도메인 머지되면 재빌드 하겠습니다