### PR TITLE
[Feature] 배송비 정책 CRUD 개발.

### DIFF
--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -52,6 +52,14 @@ public class DeliveryPolicyService {
         deliveryPolicy.updateAmount(request.minAmount());
     }
 
+    public void withdrawDeliveryPolicy(UUID deliveryPolicyId) {
+        Member member = memberValidator.getCurrentMember();
+        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
+
+        validateStoreOwner(deliveryPolicy.getStore(), member);
+        deliveryPolicyRepository.delete(deliveryPolicy);
+    }
+
     // 상점 정책 존재하는지 확인
     private void ensureStoreHasNoExistingPolicy(Store store) {
         if (deliveryPolicyRepository.existsByStore(store)) {

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.deliverypolicy.domain.entity.DeliveryPolicy;
 import com.irum.come2us.domain.deliverypolicy.domain.repository.DeliveryPolicyRepository;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyInfoResponse;
 import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.store.domain.entity.Store;
@@ -58,6 +59,12 @@ public class DeliveryPolicyService {
 
         validateStoreOwner(deliveryPolicy.getStore(), member);
         deliveryPolicyRepository.delete(deliveryPolicy);
+    }
+
+    @Transactional
+    public DeliveryPolicyInfoResponse findDeliveryPolicy(UUID deliveryPolicyId) {
+        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
+        return DeliveryPolicyInfoResponse.from(deliveryPolicy);
     }
 
     // 상점 정책 존재하는지 확인

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -37,7 +37,12 @@ public class DeliveryPolicyService {
                         request.minQuantity(),
                         request.minAmount(),
                         store);
+
+        store.setDeliveryPolicy(deliveryPolicy);
+
+        storeRepository.save(store);
         deliveryPolicyRepository.save(deliveryPolicy);
+
         return deliveryPolicy.getId();
     }
 
@@ -52,8 +57,13 @@ public class DeliveryPolicyService {
 
     public void withdrawDeliveryPolicy(UUID deliveryPolicyId) {
         DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
+        Store store = deliveryPolicy.getStore();
+
+        store.setDeliveryPolicy(null);
+        deliveryPolicy.setStore(null);
 
         deliveryPolicyRepository.delete(deliveryPolicy);
+        storeRepository.save(store);
     }
 
     @Transactional

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -40,7 +40,6 @@ public class DeliveryPolicyService {
 
         store.setDeliveryPolicy(deliveryPolicy);
 
-        storeRepository.save(store);
         deliveryPolicyRepository.save(deliveryPolicy);
     }
 
@@ -67,7 +66,6 @@ public class DeliveryPolicyService {
         deliveryPolicy.setStore(null);
 
         deliveryPolicyRepository.delete(deliveryPolicy);
-        storeRepository.save(store);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -1,0 +1,58 @@
+package com.irum.come2us.domain.deliverypolicy.application.service;
+
+import com.irum.come2us.domain.deliverypolicy.domain.entity.DeliveryPolicy;
+import com.irum.come2us.domain.deliverypolicy.domain.repository.DeliveryPolicyRepository;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
+import com.irum.come2us.domain.member.application.util.MemberValidator;
+import com.irum.come2us.domain.member.domain.entity.Member;
+import com.irum.come2us.domain.store.domain.entity.Store;
+import com.irum.come2us.domain.store.domain.repository.StoreRepository;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.DeliveryPolicyErrorCode;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeliveryPolicyService {
+    private final DeliveryPolicyRepository deliveryPolicyRepository;
+    private final StoreRepository storeRepository;
+    private final MemberValidator memberValidator;
+
+    public UUID createDeliveryPolicy(DeliveryPolicyCreateRequest request) {
+        Member member = memberValidator.getCurrentMember();
+        Store store = validateAndGetStoreByMember(member);
+        validateStoreHasNotPolicy(store);
+
+        DeliveryPolicy deliveryPolicy =
+                DeliveryPolicy.createPolicy(
+                        request.defaultDeliveryFee(),
+                        request.minQuantity(),
+                        request.minAmount(),
+                        store);
+        deliveryPolicyRepository.save(deliveryPolicy);
+        return deliveryPolicy.getId();
+    }
+
+    private void validateStoreHasNotPolicy(Store store) {
+        if (deliveryPolicyRepository.existsByStore(store)) {
+            throw new CommonException(DeliveryPolicyErrorCode.ALREADY_EXISTS);
+        }
+    }
+
+    private void validateStoreOwner(Store store, Member currentMember) {
+        if (!store.getMember().getMemberId().equals(currentMember.getMemberId())) {
+            throw new CommonException(StoreErrorCode.UNAUTHORIZED_STORE_ACCESS);
+        }
+    }
+
+    private Store validateAndGetStoreByMember(Member member) {
+        return storeRepository
+                .findByMember(member)
+                .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.deliverypolicy.application.service;
 import com.irum.come2us.domain.deliverypolicy.domain.entity.DeliveryPolicy;
 import com.irum.come2us.domain.deliverypolicy.domain.repository.DeliveryPolicyRepository;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
 import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.store.domain.entity.Store;
@@ -26,7 +27,7 @@ public class DeliveryPolicyService {
     public UUID createDeliveryPolicy(DeliveryPolicyCreateRequest request) {
         Member member = memberValidator.getCurrentMember();
         Store store = validateAndGetStoreByMember(member);
-        validateStoreHasNotPolicy(store);
+        ensureStoreHasNoExistingPolicy(store);
 
         DeliveryPolicy deliveryPolicy =
                 DeliveryPolicy.createPolicy(
@@ -38,21 +39,47 @@ public class DeliveryPolicyService {
         return deliveryPolicy.getId();
     }
 
-    private void validateStoreHasNotPolicy(Store store) {
+    public void changeDeliveryPolicy(
+            UUID deliveryPolicyId, DeliveryPolicyInfoUpdateRequest request) {
+        Member member = memberValidator.getCurrentMember();
+        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
+        Store store = validateAndGetStoreByMember(member);
+
+        validateStoreOwner(store, member);
+
+        deliveryPolicy.updateFee(request.defaultDeliveryFee());
+        deliveryPolicy.updateQuantity(request.minQuantity());
+        deliveryPolicy.updateAmount(request.minAmount());
+    }
+
+    // 상점 정책 존재하는지 확인
+    private void ensureStoreHasNoExistingPolicy(Store store) {
         if (deliveryPolicyRepository.existsByStore(store)) {
             throw new CommonException(DeliveryPolicyErrorCode.ALREADY_EXISTS);
         }
     }
 
+    // 이게 로그인된 멤버의 스토어가 맞나요?
     private void validateStoreOwner(Store store, Member currentMember) {
         if (!store.getMember().getMemberId().equals(currentMember.getMemberId())) {
             throw new CommonException(StoreErrorCode.UNAUTHORIZED_STORE_ACCESS);
         }
     }
 
+    // 상점 주인 검증
     private Store validateAndGetStoreByMember(Member member) {
         return storeRepository
                 .findByMember(member)
                 .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    // ID로 배송 정책 조회
+    private DeliveryPolicy getDeliveryPolicyById(UUID deliveryPolicyId) {
+        return deliveryPolicyRepository
+                .findById(deliveryPolicyId)
+                .orElseThrow(
+                        () ->
+                                new CommonException(
+                                        DeliveryPolicyErrorCode.DELIVERY_POLICY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -5,13 +5,13 @@ import com.irum.come2us.domain.deliverypolicy.domain.repository.DeliveryPolicyRe
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyInfoResponse;
-import com.irum.come2us.domain.member.application.util.MemberValidator;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.DeliveryPolicyErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
+import com.irum.come2us.global.util.MemberUtil;
 import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +23,12 @@ import org.springframework.stereotype.Service;
 public class DeliveryPolicyService {
     private final DeliveryPolicyRepository deliveryPolicyRepository;
     private final StoreRepository storeRepository;
-    private final MemberValidator memberValidator;
+    private final MemberUtil memberUtil;
 
     public UUID createDeliveryPolicy(DeliveryPolicyCreateRequest request) {
-        Member member = memberValidator.getCurrentMember();
+        Member member = memberUtil.getCurrentMember();
         Store store = validateAndGetStoreByMember(member);
+
         ensureStoreHasNoExistingPolicy(store);
 
         DeliveryPolicy deliveryPolicy =
@@ -42,11 +43,7 @@ public class DeliveryPolicyService {
 
     public void changeDeliveryPolicy(
             UUID deliveryPolicyId, DeliveryPolicyInfoUpdateRequest request) {
-        Member member = memberValidator.getCurrentMember();
-        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
-        Store store = validateAndGetStoreByMember(member);
-
-        validateStoreOwner(store, member);
+        DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
 
         deliveryPolicy.updateFee(request.defaultDeliveryFee());
         deliveryPolicy.updateQuantity(request.minQuantity());
@@ -54,47 +51,45 @@ public class DeliveryPolicyService {
     }
 
     public void withdrawDeliveryPolicy(UUID deliveryPolicyId) {
-        Member member = memberValidator.getCurrentMember();
-        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
+        DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
 
-        validateStoreOwner(deliveryPolicy.getStore(), member);
         deliveryPolicyRepository.delete(deliveryPolicy);
     }
 
     @Transactional
     public DeliveryPolicyInfoResponse findDeliveryPolicy(UUID deliveryPolicyId) {
-        DeliveryPolicy deliveryPolicy = getDeliveryPolicyById(deliveryPolicyId);
+        DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
         return DeliveryPolicyInfoResponse.from(deliveryPolicy);
     }
 
-    // 상점 정책 존재하는지 확인
+    // 상점에 배달비 정책이 존재하는지 확인
     private void ensureStoreHasNoExistingPolicy(Store store) {
         if (deliveryPolicyRepository.existsByStore(store)) {
             throw new CommonException(DeliveryPolicyErrorCode.ALREADY_EXISTS);
         }
     }
 
-    // 이게 로그인된 멤버의 스토어가 맞나요?
-    private void validateStoreOwner(Store store, Member currentMember) {
-        if (!store.getMember().getMemberId().equals(currentMember.getMemberId())) {
-            throw new CommonException(StoreErrorCode.UNAUTHORIZED_STORE_ACCESS);
-        }
-    }
-
-    // 상점 주인 검증
+    // 로그인된 멤버의 상점 조회
     private Store validateAndGetStoreByMember(Member member) {
         return storeRepository
                 .findByMember(member)
                 .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
     }
 
-    // ID로 배송 정책 조회
-    private DeliveryPolicy getDeliveryPolicyById(UUID deliveryPolicyId) {
-        return deliveryPolicyRepository
-                .findById(deliveryPolicyId)
-                .orElseThrow(
-                        () ->
-                                new CommonException(
-                                        DeliveryPolicyErrorCode.DELIVERY_POLICY_NOT_FOUND));
+    // 본인 소유 검증.
+    private DeliveryPolicy validDeliveryPolicy(UUID deliveryPolicyId) {
+        DeliveryPolicy deliverypolicy =
+                deliveryPolicyRepository
+                        .findById(deliveryPolicyId)
+                        .orElseThrow(
+                                () ->
+                                        new CommonException(
+                                                DeliveryPolicyErrorCode.DELIVERY_POLICY_NOT_FOUND));
+        memberUtil.assertMemberResourceAccess(deliverypolicy.getStore().getMember());
+        return deliverypolicy;
     }
 }
+
+// 상점에 이미 정책이 존재하는지 (정책 생성을 위해)
+// 상점의 존재 하는지
+// 본인 소유 검증.

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/application/service/DeliveryPolicyService.java
@@ -12,10 +12,10 @@ import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.DeliveryPolicyErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
 import com.irum.come2us.global.util.MemberUtil;
-import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -25,7 +25,7 @@ public class DeliveryPolicyService {
     private final StoreRepository storeRepository;
     private final MemberUtil memberUtil;
 
-    public UUID createDeliveryPolicy(DeliveryPolicyCreateRequest request) {
+    public void createDeliveryPolicy(DeliveryPolicyCreateRequest request) {
         Member member = memberUtil.getCurrentMember();
         Store store = validateAndGetStoreByMember(member);
 
@@ -42,17 +42,21 @@ public class DeliveryPolicyService {
 
         storeRepository.save(store);
         deliveryPolicyRepository.save(deliveryPolicy);
-
-        return deliveryPolicy.getId();
     }
 
     public void changeDeliveryPolicy(
             UUID deliveryPolicyId, DeliveryPolicyInfoUpdateRequest request) {
         DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
 
-        deliveryPolicy.updateFee(request.defaultDeliveryFee());
-        deliveryPolicy.updateQuantity(request.minQuantity());
-        deliveryPolicy.updateAmount(request.minAmount());
+        if (request.defaultDeliveryFee() != null) {
+            deliveryPolicy.updateFee(request.defaultDeliveryFee());
+        }
+        if (request.minQuantity() != null) {
+            deliveryPolicy.updateQuantity(request.minQuantity());
+        }
+        if (request.minAmount() != null) {
+            deliveryPolicy.updateAmount(request.minAmount());
+        }
     }
 
     public void withdrawDeliveryPolicy(UUID deliveryPolicyId) {
@@ -66,7 +70,7 @@ public class DeliveryPolicyService {
         storeRepository.save(store);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public DeliveryPolicyInfoResponse findDeliveryPolicy(UUID deliveryPolicyId) {
         DeliveryPolicy deliveryPolicy = validDeliveryPolicy(deliveryPolicyId);
         return DeliveryPolicyInfoResponse.from(deliveryPolicy);

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/domain/entity/DeliveryPolicy.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/domain/entity/DeliveryPolicy.java
@@ -38,12 +38,23 @@ public class DeliveryPolicy extends BaseEntity {
     @Min(0)
     private int minAmount;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    public void setStore(Store store) {
+        this.store = store;
+        if (store != null && store.getDeliveryPolicy() != this) {
+            store.setDeliveryPolicy(this);
+        }
+    }
+
     @Builder(access = AccessLevel.PRIVATE)
     private DeliveryPolicy(int defaultDeliveryFee, int minQuantity, int minAmount, Store store) {
         this.defaultDeliveryFee = defaultDeliveryFee;
         this.minQuantity = minQuantity;
         this.minAmount = minAmount;
-        //        this.store = store;
+        this.store = store;
     }
 
     public static DeliveryPolicy createPolicy(

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/domain/repository/DeliveryPolicyRepository.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/domain/repository/DeliveryPolicyRepository.java
@@ -1,0 +1,11 @@
+package com.irum.come2us.domain.deliverypolicy.domain.repository;
+
+import com.irum.come2us.domain.deliverypolicy.domain.entity.DeliveryPolicy;
+import com.irum.come2us.domain.store.domain.entity.Store;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryPolicyRepository extends JpaRepository<DeliveryPolicy, UUID> {
+
+    boolean existsByStore(Store store);
+}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.deliverypolicy.application.service.DeliveryPolicy
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyCreateResponse;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyInfoResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,14 @@ public class DeliveryPolicyController {
         log.info("배송비 정책 삭제 요청 : storeId={}", deliveryPolicyId);
         deliveryPolicyService.withdrawDeliveryPolicy(deliveryPolicyId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("{deliveryPolicyId}")
+    public ResponseEntity<DeliveryPolicyInfoResponse> getDeliveryPolicy(
+            @PathVariable UUID deliveryPolicyId) {
+        log.info("배송비 정책 조회 요청: deliveryPolicyId={}", deliveryPolicyId);
+        DeliveryPolicyInfoResponse response =
+                deliveryPolicyService.findDeliveryPolicy(deliveryPolicyId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
@@ -2,29 +2,36 @@ package com.irum.come2us.domain.deliverypolicy.presentation.controller;
 
 import com.irum.come2us.domain.deliverypolicy.application.service.DeliveryPolicyService;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyCreateResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/deliver-policy")
+@RequestMapping("/delivery-policies")
 @RequiredArgsConstructor
 @Slf4j
 public class DeliveryPolicyController {
     private final DeliveryPolicyService deliveryPolicyService;
 
     @PostMapping
-    public ResponseEntity<DeliveryPolicyCreateResponse> registerStore(
+    public ResponseEntity<DeliveryPolicyCreateResponse> registerDeliveryPolicy(
             @Valid @RequestBody DeliveryPolicyCreateRequest request) {
-        log.info("판매자 회원가입 요청: {}", request);
+        log.info("배달비 정책 등록: {}", request);
         UUID deliveryPolicyId = deliveryPolicyService.createDeliveryPolicy(request);
         return ResponseEntity.ok(new DeliveryPolicyCreateResponse(deliveryPolicyId));
+    }
+
+    @PatchMapping("/{deliveryPolicyId}")
+    public ResponseEntity<Void> updateDeliveryPolicy(
+            @PathVariable UUID deliveryPolicyId,
+            @Valid @RequestBody DeliveryPolicyInfoUpdateRequest request) {
+        log.info("배달비 정책 수정: deliveryPolicyId={}, request={}", deliveryPolicyId, request);
+        deliveryPolicyService.changeDeliveryPolicy(deliveryPolicyId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
@@ -3,12 +3,12 @@ package com.irum.come2us.domain.deliverypolicy.presentation.controller;
 import com.irum.come2us.domain.deliverypolicy.application.service.DeliveryPolicyService;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyInfoUpdateRequest;
-import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyCreateResponse;
 import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyInfoResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,11 +20,11 @@ public class DeliveryPolicyController {
     private final DeliveryPolicyService deliveryPolicyService;
 
     @PostMapping
-    public ResponseEntity<DeliveryPolicyCreateResponse> registerDeliveryPolicy(
+    public ResponseEntity<Void> registerDeliveryPolicy(
             @Valid @RequestBody DeliveryPolicyCreateRequest request) {
-        log.info("배송비 정책 등록: {}", request);
-        UUID deliveryPolicyId = deliveryPolicyService.createDeliveryPolicy(request);
-        return ResponseEntity.ok(new DeliveryPolicyCreateResponse(deliveryPolicyId));
+        log.info("배송비 정책 등록 요청: {}", request);
+        deliveryPolicyService.createDeliveryPolicy(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/{deliveryPolicyId}")
@@ -36,14 +36,14 @@ public class DeliveryPolicyController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("{deliveryPolicyId}")
+    @DeleteMapping("/{deliveryPolicyId}")
     public ResponseEntity<Void> deleteDeliveryPolicy(@PathVariable UUID deliveryPolicyId) {
         log.info("배송비 정책 삭제 요청 : storeId={}", deliveryPolicyId);
         deliveryPolicyService.withdrawDeliveryPolicy(deliveryPolicyId);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("{deliveryPolicyId}")
+    @GetMapping("/{deliveryPolicyId}")
     public ResponseEntity<DeliveryPolicyInfoResponse> getDeliveryPolicy(
             @PathVariable UUID deliveryPolicyId) {
         log.info("배송비 정책 조회 요청: deliveryPolicyId={}", deliveryPolicyId);

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
@@ -21,7 +21,7 @@ public class DeliveryPolicyController {
     @PostMapping
     public ResponseEntity<DeliveryPolicyCreateResponse> registerDeliveryPolicy(
             @Valid @RequestBody DeliveryPolicyCreateRequest request) {
-        log.info("배달비 정책 등록: {}", request);
+        log.info("배송비 정책 등록: {}", request);
         UUID deliveryPolicyId = deliveryPolicyService.createDeliveryPolicy(request);
         return ResponseEntity.ok(new DeliveryPolicyCreateResponse(deliveryPolicyId));
     }
@@ -30,8 +30,15 @@ public class DeliveryPolicyController {
     public ResponseEntity<Void> updateDeliveryPolicy(
             @PathVariable UUID deliveryPolicyId,
             @Valid @RequestBody DeliveryPolicyInfoUpdateRequest request) {
-        log.info("배달비 정책 수정: deliveryPolicyId={}, request={}", deliveryPolicyId, request);
+        log.info("배송비 정책 수정: deliveryPolicyId={}, request={}", deliveryPolicyId, request);
         deliveryPolicyService.changeDeliveryPolicy(deliveryPolicyId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("{deliveryPolicyId}")
+    public ResponseEntity<Void> deleteDeliveryPolicy(@PathVariable UUID deliveryPolicyId) {
+        log.info("배송비 정책 삭제 요청 : storeId={}", deliveryPolicyId);
+        deliveryPolicyService.withdrawDeliveryPolicy(deliveryPolicyId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/controller/DeliveryPolicyController.java
@@ -1,0 +1,30 @@
+package com.irum.come2us.domain.deliverypolicy.presentation.controller;
+
+import com.irum.come2us.domain.deliverypolicy.application.service.DeliveryPolicyService;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.request.DeliveryPolicyCreateRequest;
+import com.irum.come2us.domain.deliverypolicy.presentation.dto.response.DeliveryPolicyCreateResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/deliver-policy")
+@RequiredArgsConstructor
+@Slf4j
+public class DeliveryPolicyController {
+    private final DeliveryPolicyService deliveryPolicyService;
+
+    @PostMapping
+    public ResponseEntity<DeliveryPolicyCreateResponse> registerStore(
+            @Valid @RequestBody DeliveryPolicyCreateRequest request) {
+        log.info("판매자 회원가입 요청: {}", request);
+        UUID deliveryPolicyId = deliveryPolicyService.createDeliveryPolicy(request);
+        return ResponseEntity.ok(new DeliveryPolicyCreateResponse(deliveryPolicyId));
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyCreateRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.deliverypolicy.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record DeliveryPolicyCreateRequest(
+        @Min(value = 0, message = "기본 배송비는 필수 입력값입니다.") int defaultDeliveryFee,
+        @Min(value = 1, message = "최소 주문 수량을 입력해주세요.") int minQuantity,
+        @Min(value = 0, message = "최소 주문 금액을 입력해수세요.") int minAmount) {}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyInfoUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyInfoUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.irum.come2us.domain.deliverypolicy.presentation.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record DeliveryPolicyInfoUpdateRequest(
+        @Min(value = 0, message = "기본 배송비는 필수 입력값입니다.") int defaultDeliveryFee,
+        @Min(value = 1, message = "최소 주문 수량을 입력해주세요.") int minQuantity,
+        @Min(value = 0, message = "최소 주문 금액을 입력해수세요.") int minAmount) {}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyInfoUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/request/DeliveryPolicyInfoUpdateRequest.java
@@ -3,6 +3,6 @@ package com.irum.come2us.domain.deliverypolicy.presentation.dto.request;
 import jakarta.validation.constraints.Min;
 
 public record DeliveryPolicyInfoUpdateRequest(
-        @Min(value = 0, message = "기본 배송비는 필수 입력값입니다.") int defaultDeliveryFee,
-        @Min(value = 1, message = "최소 주문 수량을 입력해주세요.") int minQuantity,
-        @Min(value = 0, message = "최소 주문 금액을 입력해수세요.") int minAmount) {}
+        @Min(value = 0, message = "기본 배송비는 필수 입력값입니다.") Integer defaultDeliveryFee,
+        @Min(value = 1, message = "최소 주문 수량을 입력해주세요.") Integer minQuantity,
+        @Min(value = 0, message = "최소 주문 금액을 입력해수세요.") Integer minAmount) {}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/response/DeliveryPolicyCreateResponse.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/response/DeliveryPolicyCreateResponse.java
@@ -1,0 +1,5 @@
+package com.irum.come2us.domain.deliverypolicy.presentation.dto.response;
+
+import java.util.UUID;
+
+public record DeliveryPolicyCreateResponse(UUID deliveryPolicyId) {}

--- a/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/response/DeliveryPolicyInfoResponse.java
+++ b/src/main/java/com/irum/come2us/domain/deliverypolicy/presentation/dto/response/DeliveryPolicyInfoResponse.java
@@ -1,0 +1,15 @@
+package com.irum.come2us.domain.deliverypolicy.presentation.dto.response;
+
+import com.irum.come2us.domain.deliverypolicy.domain.entity.DeliveryPolicy;
+import java.util.UUID;
+
+public record DeliveryPolicyInfoResponse(
+        UUID id, int defaultDeliveryFee, int minQuantity, int minAmount) {
+    public static DeliveryPolicyInfoResponse from(DeliveryPolicy deliveryPolicy) {
+        return new DeliveryPolicyInfoResponse(
+                deliveryPolicy.getId(),
+                deliveryPolicy.getDefaultDeliveryFee(),
+                deliveryPolicy.getMinAmount(),
+                deliveryPolicy.getMinQuantity());
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/store/domain/entity/Store.java
+++ b/src/main/java/com/irum/come2us/domain/store/domain/entity/Store.java
@@ -52,8 +52,7 @@ public class Store extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_policy_id")
+    @OneToOne(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private DeliveryPolicy deliveryPolicy;
 
     public void setDeliveryPolicy(DeliveryPolicy deliveryPolicy) {

--- a/src/main/java/com/irum/come2us/domain/store/domain/entity/Store.java
+++ b/src/main/java/com/irum/come2us/domain/store/domain/entity/Store.java
@@ -56,6 +56,13 @@ public class Store extends BaseTimeEntity {
     @JoinColumn(name = "delivery_policy_id")
     private DeliveryPolicy deliveryPolicy;
 
+    public void setDeliveryPolicy(DeliveryPolicy deliveryPolicy) {
+        this.deliveryPolicy = deliveryPolicy;
+        if (deliveryPolicy != null && deliveryPolicy.getStore() != this) {
+            deliveryPolicy.setStore(this);
+        }
+    }
+
     @Builder(access = AccessLevel.PRIVATE)
     private Store(
             String name,

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/DeliveryPolicyErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/DeliveryPolicyErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DeliveryPolicyErrorCode implements BaseErrorCode {
     ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 상점의 배송비 정책이 존재합니다."),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "배송비 정책을 찾을 수 없습니다.");
+    DELIVERY_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송비 정책을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/DeliveryPolicyErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/DeliveryPolicyErrorCode.java
@@ -1,0 +1,20 @@
+package com.irum.come2us.global.presentation.advice.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum DeliveryPolicyErrorCode implements BaseErrorCode {
+    ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 상점의 배송비 정책이 존재합니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "배송비 정책을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String errorClassName() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #139 
📌 작업 내용 및 특이사항

- **배송비 정책(DeliveryPolicy) CRUD 기능 구현**
  - DeliveryPolicy 생성(Create)
    - 기본 배송비(defaultDeliveryFee), 최소 주문 수량(minQuantity), 최소 주문 금액(minAmount) 필드 기반 정책 등록
    - Store와 1:1 관계로 매핑되어, 상점별 하나의 배송비 정책만 생성 가능하도록 구성
  - DeliveryPolicy 조회(Read)
    - 개별 정책 ID(UUID)로 단건 조회 (`GET /delivery-policies/{deliveryPolicyId}`)
    - DTO 변환 시 `DeliveryPolicyInfoResponse.from()` 사용
  - DeliveryPolicy 수정(Update)
    - 배송비, 최소 수량, 최소 금액을 개별적으로 수정 가능 (`PATCH /delivery-policies/{deliveryPolicyId}`)
  - DeliveryPolicy 삭제(Delete)
    - `@SQLDelete` + `@Where` 사용 → soft delete 처리 (`deleted_at` 컬럼 업데이트)
  - **연관관계 설정**
    - Store ↔ DeliveryPolicy 양방향 매핑 구성  
      - `Store.setDeliveryPolicy(DeliveryPolicy)`  
      - `DeliveryPolicy.setStore(Store)`  
      - 두 엔티티 간 무한 참조 방지를 위해 상호 검증 로직 포함

- **Repository**
  - `DeliveryPolicyRepository`  
    - `existsByStore(Store store)` 메서드 추가 → 상점에 중복 정책 생성 방지

- **Controller**
  - `DeliveryPolicyController`
    - `/delivery-policies` 엔드포인트로 CRUD 구현 완료
    - Request/Response DTO를 명확히 구분하여 관리

- **DTO**
  - `DeliveryPolicyCreateRequest` : 생성 시 필수 필드 검증(`@Min` 제약)
  - `DeliveryPolicyCreateResponse` : 생성 결과로 deliveryPolicyId 반환
  - `DeliveryPolicyInfoResponse` : 정책 상세 조회용 응답 DTO

---

📚 질문사항 / 의견을 주셨으면 하는 부분,

- Store 엔티티에 `setDeliveryPolicy()` 추가됨 (양방향 연관관계 완성) -> 이 부분이 조금 마음에 걸리는데 의견 부탁드립니다.
- validDeliveryPolicy-> 서비스단에있는 본인 소유 검증 메서드 이렇게 하면 되는지 확인 부탁드립니다.!

