### PR TITLE
[Refactor] Product 응답 포맷 통일화 & MemberUtil 적용

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -17,14 +17,11 @@ import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
-import com.irum.come2us.global.security.MemberDetails;
+import com.irum.come2us.global.util.MemberUtil;
 import java.util.List;
 import java.util.UUID;
-
-import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,7 +45,9 @@ public class ProductService {
                         .findByMember(member)
                         .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
 
-//        memberUtil.assertMemberResourceAccess(store.getMember());     // Store를 현재 인증된 유저 기반으로 조회했기 때문에, 다시 한 번 검증할 필요 없다고 생각
+        // memberUtil.assertMemberResourceAccess(store.getMember());
+        // Store를 현재 인증된 유저 기반으로 조회했기 때문에, 다시 한 번 검증할 필요 없다고 생각
+
         if (!member.getRole().equals(Role.OWNER)) {
             log.warn("상품 등록 실패: 비인가 사용자 memberId={}", member.getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
@@ -282,7 +281,8 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
 
-        memberUtil.assertMemberResourceAccess(optionValue.getOptionGroup().getProduct().getStore().getMember());
+        memberUtil.assertMemberResourceAccess(
+                optionValue.getOptionGroup().getProduct().getStore().getMember());
 
         if ((request.name() == null || request.name().isBlank())
                 && request.stockQuantity() == null
@@ -332,7 +332,8 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
 
-        memberUtil.assertMemberResourceAccess(optionValue.getOptionGroup().getProduct().getStore().getMember());
+        memberUtil.assertMemberResourceAccess(
+                optionValue.getOptionGroup().getProduct().getStore().getMember());
 
         optionValueRepository.delete(optionValue);
         log.info("상품 옵션 값 삭제 완료: valueId={}", optionValueId);

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -20,6 +20,8 @@ import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErro
 import com.irum.come2us.global.security.MemberDetails;
 import java.util.List;
 import java.util.UUID;
+
+import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,15 +38,17 @@ public class ProductService {
     private final ProductOptionValueRepository optionValueRepository;
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
+    private final MemberUtil memberUtil;
 
     public ProductResponse createProduct(ProductCreateRequest request) {
-        Member member = getCurrentUser();
+        Member member = memberUtil.getCurrentMember();
 
         Store store =
                 storeRepository
                         .findByMember(member)
                         .orElseThrow(() -> new CommonException(StoreErrorCode.STORE_NOT_FOUND));
 
+//        memberUtil.assertMemberResourceAccess(store.getMember());     // Store를 현재 인증된 유저 기반으로 조회했기 때문에, 다시 한 번 검증할 필요 없다고 생각
         if (!member.getRole().equals(Role.OWNER)) {
             log.warn("상품 등록 실패: 비인가 사용자 memberId={}", member.getMemberId());
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
@@ -83,20 +87,12 @@ public class ProductService {
     }
 
     public ProductResponse updateProduct(UUID productId, ProductUpdateRequest request) {
-        Member member = getCurrentUser();
-
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member)) {
-            log.warn(
-                    "상품 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
-                    member.getMemberId(),
-                    product.getStore().getMember().getMemberId());
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         if (request.name() == null
                 && request.description() == null
@@ -152,21 +148,12 @@ public class ProductService {
 
     public ProductResponse updateProductPublicStatus(
             UUID productId, ProductPublicUpdateRequest request) {
-        Member member = getCurrentUser();
-
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member)
-                && !member.getRole().equals(Role.MANAGER)) {
-            log.warn(
-                    "상품 공개 상태 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
-                    member.getMemberId(),
-                    product.getStore().getMember().getMemberId());
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         boolean newStatus = request.isPublic();
         boolean currentStatus = product.isPublic();
@@ -220,20 +207,12 @@ public class ProductService {
     }
 
     public void deleteProduct(UUID productId) {
-        Member member = getCurrentUser();
-
         Product product =
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getStore().getMember().equals(member)) {
-            log.warn(
-                    "상품 삭제 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
-                    member.getMemberId(),
-                    product.getStore().getMember().getMemberId());
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         productRepository.delete(product);
         log.info("상품 삭제 완료: productId={}", productId);
@@ -244,6 +223,8 @@ public class ProductService {
                 productRepository
                         .findById(productId)
                         .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
         ProductOptionGroup group = ProductOptionGroup.createOptionGroup(product, request.name());
         product.addOptionGroup(group);
@@ -266,6 +247,8 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
 
+        memberUtil.assertMemberResourceAccess(optionGroup.getProduct().getStore().getMember());
+
         ProductOptionValue.createOptionValue(
                 optionGroup,
                 request.name(),
@@ -284,6 +267,8 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
 
+        memberUtil.assertMemberResourceAccess(optionGroup.getProduct().getStore().getMember());
+
         optionGroup.updateOptionGroupName(request.name());
 
         return ProductOptionGroupResponse.from(optionGroup);
@@ -296,6 +281,8 @@ public class ProductService {
                         .findById(optionValueId)
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
+
+        memberUtil.assertMemberResourceAccess(optionValue.getOptionGroup().getProduct().getStore().getMember());
 
         if ((request.name() == null || request.name().isBlank())
                 && request.stockQuantity() == null
@@ -332,6 +319,8 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_GROUP_NOT_FOUND));
 
+        memberUtil.assertMemberResourceAccess(optionGroup.getProduct().getStore().getMember());
+
         optionGroupRepository.delete(optionGroup);
         log.info("상품 옵션 그룹 삭제 완료: groupId={}", optionGroupId);
     }
@@ -343,25 +332,9 @@ public class ProductService {
                         .orElseThrow(
                                 () -> new CommonException(ProductErrorCode.OPTION_VALUE_NOT_FOUND));
 
+        memberUtil.assertMemberResourceAccess(optionValue.getOptionGroup().getProduct().getStore().getMember());
+
         optionValueRepository.delete(optionValue);
         log.info("상품 옵션 값 삭제 완료: valueId={}", optionValueId);
-    }
-
-    private Member getCurrentUser() {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null
-                || !(authentication.getPrincipal() instanceof MemberDetails details)) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
-
-        try {
-            Long memberId = Long.parseLong(details.getUsername());
-            return memberRepository
-                    .findById(memberId)
-                    .orElseThrow(() -> new CommonException(MemberErrorCode.MEMBER_NOT_FOUND));
-        } catch (NumberFormatException e) {
-            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
-        }
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -19,49 +19,40 @@ public class ProductController {
     private final ProductService productService;
 
     @PostMapping
-    public ResponseEntity<ProductResponse> createProduct(
-            @Valid @RequestBody ProductCreateRequest request) {
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductResponse createProduct(@Valid @RequestBody ProductCreateRequest request) {
         log.info("상품 등록 요청: {}", request);
-        ProductResponse response = productService.createProduct(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-
-        // TODO: Security 적용
+        return productService.createProduct(request);
     }
 
     @PatchMapping("/{productId}")
-    public ResponseEntity<ProductResponse> updateProduct(
+    public ProductResponse updateProduct(
             @PathVariable UUID productId, @RequestBody ProductUpdateRequest request) {
         log.info("상품 정보 수정 요청: productId={}, request={}", productId, request);
-        ProductResponse response = productService.updateProduct(productId, request);
-        return ResponseEntity.ok(response);
-
-        // TODO: Security 적용
+        return productService.updateProduct(productId, request);
     }
 
     @PatchMapping("/{productId}/public")
-    public ResponseEntity<ProductResponse> updateProductPublicStatus(
+    public ProductResponse updateProductPublicStatus(
             @PathVariable UUID productId, @Valid @RequestBody ProductPublicUpdateRequest request) {
         log.info("상품 공개 상태 변경 요청: productId={}, isPublic={}", productId, request.isPublic());
-        ProductResponse response = productService.updateProductPublicStatus(productId, request);
-        return ResponseEntity.ok(response);
+        return productService.updateProductPublicStatus(productId, request);
     }
 
     @GetMapping
-    public ResponseEntity<ProductCursorResponse> getProductList(
+    public ProductCursorResponse getProductList(
             @RequestParam(required = false) UUID cursor,
             @RequestParam(required = false) Integer size,
             @RequestParam(required = false) String keyword) {
         log.info("상품 목록 조회 요청: cursor={}, size={}, keyword={}", cursor, size, keyword);
-        ProductCursorResponse response = productService.getProductList(cursor, size, keyword);
-        return ResponseEntity.ok(response);
+        return productService.getProductList(cursor, size, keyword);
     }
 
     @GetMapping("/{productId}")
-    public ResponseEntity<ProductDetailResponse> getProduct(@PathVariable UUID productId) {
+    public ProductDetailResponse getProduct(@PathVariable UUID productId) {
         log.info("상품 상세 조회 요청: productId={}", productId);
 
-        ProductDetailResponse response = productService.getProductById(productId);
-        return ResponseEntity.ok(response);
+        return productService.getProductById(productId);
     }
 
     @DeleteMapping("/{productId}")
@@ -89,23 +80,19 @@ public class ProductController {
     }
 
     @PatchMapping("/options/{optionGroupId}")
-    public ResponseEntity<ProductOptionGroupResponse> updateProductOptionGroup(
+    public ProductOptionGroupResponse updateProductOptionGroup(
             @PathVariable UUID optionGroupId,
             @Valid @RequestBody ProductOptionGroupRequest request) {
         log.info("상품 옵션 그룹 수정 요청: groupId={}", optionGroupId);
-        ProductOptionGroupResponse response =
-                productService.updateProductOptionGroup(optionGroupId, request);
-        return ResponseEntity.ok(response);
+        return productService.updateProductOptionGroup(optionGroupId, request);
     }
 
     @PatchMapping("/options/values/{optionValueId}")
-    public ResponseEntity<ProductOptionValueResponse> updateProductOptionValue(
+    public ProductOptionValueResponse updateProductOptionValue(
             @PathVariable UUID optionValueId,
             @Valid @RequestBody ProductOptionValueUpdateRequest request) {
         log.info("상품 옵션 값 수정 요청: valueId={}", optionValueId);
-        ProductOptionValueResponse response =
-                productService.updateProductOptionValue(optionValueId, request);
-        return ResponseEntity.ok(response);
+        return productService.updateProductOptionValue(optionValueId, request);
     }
 
     @DeleteMapping("/options/{optionGroupId}")


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #193

📌 **작업 내용 및 특이사항**

**[ProductController]**
- 응답 포맷 통일화: `ResponseEntity<Response>` -> `Response`

**[ProductService]**
- MemberUtil 사용하여 로그인된 유저 검증 및 리소스 접근 제어 구현

📚 **참고사항**
- 기존에는 Log를 자세히 남겼었는데, `assertMemberResourceAccess()`를 사용하며 정확한 로그를 남길 수 없어졌습니다.
- 만일 리소스 별 자세한 로그를 남기려 할 필요가 있다면 어떻게 처리해야할지 고민이 필요할 것 같습니다.
```java
        if (!product.getStore().getMember().equals(member)) {
            log.warn(
                    "상품 수정 실패: 비인가 사용자 memberId={}, storeOwnerId={}",
                    member.getMemberId(),
                    product.getStore().getMember().getMemberId());
            throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
        }
```