### PR TITLE
[Feature] 상품-카테고리 매핑

### DIFF
--- a/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
@@ -4,7 +4,12 @@ import com.irum.come2us.domain.category.domain.entity.Category;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
     List<Category> findByParentIsNull(); // 루트 카테고리 조회
+
+    @Query("SELECT c FROM Category c WHERE c.parent.categoryId = :parentId")
+    List<Category> findChildrenByParentId(@Param("parentId") UUID parentId);
 }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryInfoResponse.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryInfoResponse.java
@@ -1,0 +1,11 @@
+package com.irum.come2us.domain.category.presentation.dto.response;
+
+import com.irum.come2us.domain.category.domain.entity.Category;
+import java.util.UUID;
+
+public record CategoryInfoResponse(UUID categoryId, String name, int depth) {
+    public static CategoryInfoResponse from(Category category) {
+        return new CategoryInfoResponse(
+                category.getCategoryId(), category.getName(), category.getDepth());
+    }
+}

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -21,6 +21,7 @@ import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErr
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
 import com.irum.come2us.global.util.MemberUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -207,7 +208,7 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public ProductCursorResponse getProductList(UUID cursor, Integer size, String keyword) {
+    public ProductCursorResponse getProductList(UUID categoryId, UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
             size = 10;
@@ -215,7 +216,13 @@ public class ProductService {
 
         List<ProductResponse> products;
 
-        if (keyword != null && !keyword.trim().isEmpty()) {
+        if (categoryId != null && keyword != null && !keyword.trim().isEmpty()) {
+            List<UUID> categoryIds = getAllDescendantCategoryIds(categoryId);
+            products = productRepository.findProductsByCategoryIdsAndKeyword(cursor, size, categoryIds, keyword);
+        } else if (categoryId != null) {
+            List<UUID> categoryIds = getAllDescendantCategoryIds(categoryId);
+            products = productRepository.findProductsByCategoryIds(cursor, size, categoryIds);
+        } else if (keyword != null && !keyword.trim().isEmpty()) {
             log.info("상품 검색 요청: keyword={}, cursor={}, size={}", keyword, cursor, size);
             products = productRepository.findProductsByKeyword(cursor, size, keyword);
         } else {
@@ -369,5 +376,19 @@ public class ProductService {
 
         optionValueRepository.delete(optionValue);
         log.info("상품 옵션 값 삭제 완료: valueId={}", optionValueId);
+    }
+
+    private List<UUID> getAllDescendantCategoryIds(UUID categoryId) {
+        List<UUID> ids = new ArrayList<>();
+        collectDescendants(categoryId, ids);
+        return ids;
+    }
+
+    private void collectDescendants(UUID categoryId, List<UUID> ids) {
+        ids.add(categoryId);
+        List<Category> children = categoryRepository.findChildrenByParentId(categoryId);
+        for (Category child : children) {
+            collectDescendants(child.getCategoryId(), ids);
+        }
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -24,8 +24,6 @@ import com.irum.come2us.global.util.MemberUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -208,7 +206,8 @@ public class ProductService {
     }
 
     @Transactional(readOnly = true)
-    public ProductCursorResponse getProductList(UUID categoryId, UUID cursor, Integer size, String keyword) {
+    public ProductCursorResponse getProductList(
+            UUID categoryId, UUID cursor, Integer size, String keyword) {
         if (size == null || (size != 10 && size != 30 && size != 50)) {
             log.warn("허용되지 않은 size 요청: {} -> 기본값 10으로 대체", size);
             size = 10;
@@ -218,7 +217,9 @@ public class ProductService {
 
         if (categoryId != null && keyword != null && !keyword.trim().isEmpty()) {
             List<UUID> categoryIds = getAllDescendantCategoryIds(categoryId);
-            products = productRepository.findProductsByCategoryIdsAndKeyword(cursor, size, categoryIds, keyword);
+            products =
+                    productRepository.findProductsByCategoryIdsAndKeyword(
+                            cursor, size, categoryIds, keyword);
         } else if (categoryId != null) {
             List<UUID> categoryIds = getAllDescendantCategoryIds(categoryId);
             products = productRepository.findProductsByCategoryIds(cursor, size, categoryIds);

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductService.java
@@ -1,5 +1,7 @@
 package com.irum.come2us.domain.product.application.service;
 
+import com.irum.come2us.domain.category.domain.entity.Category;
+import com.irum.come2us.domain.category.domain.repository.CategoryRepository;
 import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.member.domain.entity.enums.Role;
 import com.irum.come2us.domain.member.domain.repository.MemberRepository;
@@ -14,12 +16,15 @@ import com.irum.come2us.domain.product.presentation.dto.response.*;
 import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.domain.store.domain.repository.StoreRepository;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.MemberErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.StoreErrorCode;
 import com.irum.come2us.global.util.MemberUtil;
 import java.util.List;
 import java.util.UUID;
+
+import com.irum.come2us.global.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,6 +40,7 @@ public class ProductService {
     private final ProductOptionValueRepository optionValueRepository;
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
+    private final CategoryRepository categoryRepository;
     private final MemberUtil memberUtil;
 
     public ProductResponse createProduct(ProductCreateRequest request) {
@@ -53,9 +59,16 @@ public class ProductService {
             throw new CommonException(MemberErrorCode.UNAUTHORIZED_ACCESS);
         }
 
+        Category category =
+                categoryRepository
+                        .findById(request.categoryId())
+                        .orElseThrow(
+                                () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
         Product product =
                 Product.createProduct(
                         store,
+                        category,
                         request.name(),
                         request.description(),
                         request.detailDescription(),
@@ -171,6 +184,25 @@ public class ProductService {
                 product.getPrice(),
                 newStatus);
 
+        return ProductResponse.from(product);
+    }
+
+    public ProductResponse updateProductCategory(
+            UUID productId, ProductCategoryUpdateRequest request) {
+        Product product =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new CommonException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        memberUtil.assertMemberResourceAccess(product.getStore().getMember());
+
+        Category category =
+                categoryRepository
+                        .findById(request.categoryId())
+                        .orElseThrow(
+                                () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        product.updateCategory(category);
         return ProductResponse.from(product);
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -1,7 +1,10 @@
 package com.irum.come2us.domain.product.domain.entity;
 
+import com.irum.come2us.domain.category.domain.entity.Category;
 import com.irum.come2us.domain.store.domain.entity.Store;
 import com.irum.come2us.global.domain.BaseEntity;
+import com.irum.come2us.global.presentation.advice.exception.CommonException;
+import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,15 +57,21 @@ public class Product extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
     @Builder(access = AccessLevel.PRIVATE)
     private Product(
             Store store,
+            Category category,
             String name,
             String description,
             boolean isPublic,
             String detailDescription,
             int price) {
         this.store = store;
+        this.category = category;
         this.name = name;
         this.description = description;
         this.isPublic = isPublic;
@@ -72,13 +81,20 @@ public class Product extends BaseEntity {
 
     public static Product createProduct(
             Store store,
+            Category category,
             String name,
             String description,
             String detailDescription,
             int price,
             boolean isPublic) {
+
+        if (category.getDepth() != 3) {
+            throw new CommonException(CategoryErrorCode.INVALID_CATEGORY_DEPTH);
+        }
+
         return Product.builder()
                 .store(store)
+                .category(category)
                 .name(name)
                 .description(description)
                 .detailDescription(detailDescription)
@@ -109,5 +125,12 @@ public class Product extends BaseEntity {
         optionGroups.add(group);
     }
 
-    // TODO: Category, 이미지 매핑
+    public void updateCategory(Category category) {
+        if (category.getDepth() != 3) {
+            throw new CommonException(CategoryErrorCode.INVALID_CATEGORY_DEPTH);
+        }
+        this.category = category;
+    }
+
+    // TODO: 이미지 매핑
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/Product.java
@@ -132,5 +132,5 @@ public class Product extends BaseEntity {
         this.category = category;
     }
 
-    // TODO: 이미지 매핑
+    // TODO: 이미지 매핑, 리뷰 매핑
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -10,4 +10,8 @@ public interface ProductRepositoryCustom {
     List<ProductResponse> findProductsByKeyword(UUID cursor, int size, String keyword);
 
     List<ProductResponse> findProductsByStoreWithCursor(UUID storeId, UUID cursor, int size);
+
+    List<ProductResponse> findProductsByCategoryIds(UUID cursor, int size, List<UUID> categoryIds);
+
+    List<ProductResponse> findProductsByCategoryIdsAndKeyword(UUID cursor, int size, List<UUID> categoryIds, String keyword);
 }

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductRepositoryCustom.java
@@ -13,5 +13,6 @@ public interface ProductRepositoryCustom {
 
     List<ProductResponse> findProductsByCategoryIds(UUID cursor, int size, List<UUID> categoryIds);
 
-    List<ProductResponse> findProductsByCategoryIdsAndKeyword(UUID cursor, int size, List<UUID> categoryIds, String keyword);
+    List<ProductResponse> findProductsByCategoryIdsAndKeyword(
+            UUID cursor, int size, List<UUID> categoryIds, String keyword);
 }

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -101,20 +101,22 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public List<ProductResponse> findProductsByCategoryIds(UUID cursor, int size, List<UUID> categoryIds) {
+    public List<ProductResponse> findProductsByCategoryIds(
+            UUID cursor, int size, List<UUID> categoryIds) {
         QProduct product = QProduct.product;
 
         return queryFactory
-                .select(Projections.constructor(
-                        ProductResponse.class,
-                        product.id,
-                        product.name,
-                        product.description,
-                        product.detailDescription,
-                        product.price,
-                        product.isPublic,
-                        product.avgRating,
-                        product.reviewCount))
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
                 .from(product)
                 .where(
                         product.isPublic.isTrue(),
@@ -126,20 +128,22 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public List<ProductResponse> findProductsByCategoryIdsAndKeyword(UUID cursor, int size, List<UUID> categoryIds, String keyword) {
+    public List<ProductResponse> findProductsByCategoryIdsAndKeyword(
+            UUID cursor, int size, List<UUID> categoryIds, String keyword) {
         QProduct product = QProduct.product;
 
         return queryFactory
-                .select(Projections.constructor(
-                        ProductResponse.class,
-                        product.id,
-                        product.name,
-                        product.description,
-                        product.detailDescription,
-                        product.price,
-                        product.isPublic,
-                        product.avgRating,
-                        product.reviewCount))
+                .select(
+                        Projections.constructor(
+                                ProductResponse.class,
+                                product.id,
+                                product.name,
+                                product.description,
+                                product.detailDescription,
+                                product.price,
+                                product.isPublic,
+                                product.avgRating,
+                                product.reviewCount))
                 .from(product)
                 .where(
                         product.isPublic.isTrue(),

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -42,7 +42,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.price,
                                 product.isPublic,
                                 product.avgRating,
-                                product.reviewCount))
+                                product.reviewCount,
+                                product.category.categoryId,
+                                product.category.name))
                 .from(product)
                 .where(product.isPublic.isTrue(), ltCursor(cursor, product))
                 .orderBy(product.id.desc())
@@ -65,7 +67,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.price,
                                 product.isPublic,
                                 product.avgRating,
-                                product.reviewCount))
+                                product.reviewCount,
+                                product.category.categoryId,
+                                product.category.name))
                 .from(product)
                 .where(
                         product.isPublic.isTrue(),
@@ -116,7 +120,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.price,
                                 product.isPublic,
                                 product.avgRating,
-                                product.reviewCount))
+                                product.reviewCount,
+                                product.category.categoryId,
+                                product.category.name))
                 .from(product)
                 .where(
                         product.isPublic.isTrue(),
@@ -143,7 +149,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                                 product.price,
                                 product.isPublic,
                                 product.avgRating,
-                                product.reviewCount))
+                                product.reviewCount,
+                                product.category.categoryId,
+                                product.category.name))
                 .from(product)
                 .where(
                         product.isPublic.isTrue(),

--- a/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/irum/come2us/domain/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -99,4 +99,55 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .limit(size)
                 .fetch();
     }
+
+    @Override
+    public List<ProductResponse> findProductsByCategoryIds(UUID cursor, int size, List<UUID> categoryIds) {
+        QProduct product = QProduct.product;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ProductResponse.class,
+                        product.id,
+                        product.name,
+                        product.description,
+                        product.detailDescription,
+                        product.price,
+                        product.isPublic,
+                        product.avgRating,
+                        product.reviewCount))
+                .from(product)
+                .where(
+                        product.isPublic.isTrue(),
+                        ltCursor(cursor, product),
+                        product.category.categoryId.in(categoryIds))
+                .orderBy(product.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<ProductResponse> findProductsByCategoryIdsAndKeyword(UUID cursor, int size, List<UUID> categoryIds, String keyword) {
+        QProduct product = QProduct.product;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        ProductResponse.class,
+                        product.id,
+                        product.name,
+                        product.description,
+                        product.detailDescription,
+                        product.price,
+                        product.isPublic,
+                        product.avgRating,
+                        product.reviewCount))
+                .from(product)
+                .where(
+                        product.isPublic.isTrue(),
+                        ltCursor(cursor, product),
+                        product.category.categoryId.in(categoryIds),
+                        containsKeyword(keyword, product))
+                .orderBy(product.id.desc())
+                .limit(size)
+                .fetch();
+    }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -53,7 +53,12 @@ public class ProductController {
             @RequestParam(required = false) UUID cursor,
             @RequestParam(required = false) Integer size,
             @RequestParam(required = false) String keyword) {
-        log.info("상품 목록 조회 요청: categoryId={}, cursor={}, size={}, keyword={}", categoryId, cursor, size, keyword);
+        log.info(
+                "상품 목록 조회 요청: categoryId={}, cursor={}, size={}, keyword={}",
+                categoryId,
+                cursor,
+                size,
+                keyword);
         return productService.getProductList(categoryId, cursor, size, keyword);
     }
 

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -39,6 +39,14 @@ public class ProductController {
         return productService.updateProductPublicStatus(productId, request);
     }
 
+    @PatchMapping("/{productId}/categories")
+    public ProductResponse updateProductCategory(
+            @PathVariable UUID productId,
+            @Valid @RequestBody ProductCategoryUpdateRequest request) {
+        log.info("상품 카테고리 변경 요청: productId={}", productId);
+        return productService.updateProductCategory(productId, request);
+    }
+
     @GetMapping
     public ProductCursorResponse getProductList(
             @RequestParam(required = false) UUID cursor,

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductController.java
@@ -49,11 +49,12 @@ public class ProductController {
 
     @GetMapping
     public ProductCursorResponse getProductList(
+            @RequestParam(required = false) UUID categoryId,
             @RequestParam(required = false) UUID cursor,
             @RequestParam(required = false) Integer size,
             @RequestParam(required = false) String keyword) {
-        log.info("상품 목록 조회 요청: cursor={}, size={}, keyword={}", cursor, size, keyword);
-        return productService.getProductList(cursor, size, keyword);
+        log.info("상품 목록 조회 요청: categoryId={}, cursor={}, size={}, keyword={}", categoryId, cursor, size, keyword);
+        return productService.getProductList(categoryId, cursor, size, keyword);
     }
 
     @GetMapping("/{productId}")

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCategoryUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCategoryUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.irum.come2us.domain.product.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ProductCategoryUpdateRequest(
+        @NotNull(message = "상품 카테고리는 필수 입력값입니다.") UUID categoryId) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/request/ProductCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.UUID;
 
 public record ProductCreateRequest(
         @NotBlank(message = "상품명은 필수 입력값입니다.") String name,
@@ -11,4 +12,5 @@ public record ProductCreateRequest(
         @NotBlank(message = "상품 상세 설명은 필수 입력값입니다.") String detailDescription,
         @NotNull(message = "상품 공개 여부는 필수 입력값입니다.") Boolean isPublic,
         @Min(value = 0, message = "상품 가격은 0 이상이어야 합니다.") int price,
+        @NotNull(message = "상품 카테고리는 필수 입력값입니다.") UUID categoryId,
         List<ProductOptionGroupRequest> optionGroups) {}

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
@@ -1,6 +1,9 @@
 package com.irum.come2us.domain.product.presentation.dto.response;
 
+import com.irum.come2us.domain.category.presentation.dto.response.CategoryInfoResponse;
 import com.irum.come2us.domain.product.domain.entity.Product;
+import com.irum.come2us.domain.store.presentation.dto.response.StoreInfoResponse;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -25,8 +28,8 @@ public record ProductDetailResponse(
         boolean isPublic,
         Double avgRating,
         Integer reviewCount,
-        // TODO: StoreInfoResponse store,
-        // TODO: CategoryInfoResponse category,
+        StoreInfoResponse store,
+        CategoryInfoResponse category,
         // TODO: List<ImageResponse> images,
         List<ProductOptionGroupResponse> optionGroups) {
     public static ProductDetailResponse from(Product product) {
@@ -39,6 +42,8 @@ public record ProductDetailResponse(
                 product.isPublic(),
                 product.getAvgRating(),
                 product.getReviewCount(),
+                StoreInfoResponse.from(product.getStore()),
+                CategoryInfoResponse.from(product.getCategory()),
                 product.getOptionGroups().stream().map(ProductOptionGroupResponse::from).toList());
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductDetailResponse.java
@@ -3,7 +3,6 @@ package com.irum.come2us.domain.product.presentation.dto.response;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryInfoResponse;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.store.presentation.dto.response.StoreInfoResponse;
-
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/dto/response/ProductResponse.java
@@ -21,7 +21,9 @@ public record ProductResponse(
         int price,
         boolean isPublic,
         Double avgRating,
-        Integer reviewCount) {
+        Integer reviewCount,
+        UUID categoryId,
+        String categoryName) {
     public static ProductResponse from(Product product) {
         return new ProductResponse(
                 product.getId(),
@@ -31,6 +33,8 @@ public record ProductResponse(
                 product.getPrice(),
                 product.isPublic(),
                 product.getAvgRating(),
-                product.getReviewCount());
+                product.getReviewCount(),
+                product.getCategory().getCategoryId(),
+                product.getCategory().getName());
     }
 }

--- a/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/CategoryErrorCode.java
+++ b/src/main/java/com/irum/come2us/global/presentation/advice/exception/errorcode/CategoryErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CategoryErrorCode implements BaseErrorCode {
+    INVALID_CATEGORY_DEPTH(HttpStatus.BAD_REQUEST, "상품은 최하위 카테고리에만 속할 수 있습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 정보를 찾을 수 없습니다."),
     CATEGORY_NOT_MODIFIED(HttpStatus.BAD_REQUEST, "카테고리 수정에 대한 변경된 내용이 없습니다."),
     CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리입니다."),


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #191

## 📌 **작업 내용 및 특이사항**
### Product ↔ Category 연관관계 추가
- `Product` 엔티티에 `@ManyToOne`으로 `Category` 필드 추가
- 상품은 반드시 최하위(Depth=3) 카테고리에만 속할 수 있도록 검증 추가 (변경 가능성 존재)
  - `createProduct()` 및 `updateCategory()`에서 depth 검증 로직 수행
  - 잘못된 카테고리일 경우 `CategoryErrorCode.INVALID_CATEGORY_DEPTH` 발생

### 상품 생성/수정 시 카테고리 연동
```java
PATCH /products/{productId}/categories
```
- `ProductCreateRequest`에 `categoryId` 필드 추가
- `ProductService.createProduct()`에서 Category 조회 및 유효성 검증 수행
- `ProductService.updateProductCategory()` 메서드 추가로 카테고리 변경 API 분리

### 카테고리별 상품 조회 구현
```java
GET /products?categoryId={uuid}
```
- `/products` API에서 `categoryId`를 `@RequestParam`으로 받도록 수정
- 조회 조건 설정
  - categoryId만 있으면 해당 카테고리 및 하위 카테고리 전체 상품 조회
  - keyword만 있으면 전체 상품 중 검색어 일치 상품 조회
  - categoryId + keyword 함께 있으면 AND 조건으로 필터링
- getProductList() 로직 개선
  - categoryId가 있을 경우 하위 카테고리까지 포함하여 조회
  - 예시) '생활용품' -> '헤어' -> '샴푸', '린스' 카테고리가 있을 때, '헤어'로 필터링을 걸면 '샴푸', '린스' 상품이 함께 조회됨


## 📚 **참고사항**
