### PR TITLE
[Refactor] 카테고리 계층별 조회 구현

### DIFF
--- a/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
+++ b/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.irum.come2us.domain.category.domain.entity.Category;
 import com.irum.come2us.domain.category.domain.repository.CategoryRepository;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryUpdateRequest;
+import com.irum.come2us.domain.category.presentation.dto.response.CategoryInfoResponse;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
@@ -22,16 +23,16 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
-    public List<CategoryResponse> findRootCategories() {
+    public List<CategoryInfoResponse> findRootCategories() {
         return categoryRepository.findByParentIsNull().stream()
-                .map(CategoryResponse::fromEntity)
+                .map(CategoryInfoResponse::from)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<CategoryResponse> findByParentId(UUID parentId) {
+    public List<CategoryInfoResponse> findByParentId(UUID parentId) {
         return categoryRepository.findChildrenByParentId(parentId).stream()
-                .map(CategoryResponse::fromEntity)
+                .map(CategoryInfoResponse::from)
                 .toList();
     }
 

--- a/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
+++ b/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
@@ -22,10 +22,17 @@ public class CategoryService {
 
     // ------------------- 전체 조회 -------------------
     @Transactional(readOnly = true)
-    public List<CategoryResponse> findAllCategories() {
-        return categoryRepository.findAll().stream()
+    public List<CategoryResponse> findRootCategories() {
+        return categoryRepository.findByParentIsNull().stream()
                 .map(CategoryResponse::fromEntity)
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> findByParentId(UUID parentId) {
+        return categoryRepository.findChildrenByParentId(parentId).stream()
+                .map(CategoryResponse::fromEntity)
+                .toList();
     }
 
     // ------------------- 단일 조회 -------------------

--- a/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
+++ b/src/main/java/com/irum/come2us/domain/category/application/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.category.application.service;
 import com.irum.come2us.domain.category.domain.entity.Category;
 import com.irum.come2us.domain.category.domain.repository.CategoryRepository;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
+import com.irum.come2us.domain.category.presentation.dto.request.CategoryUpdateRequest;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
@@ -20,7 +21,6 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    // ------------------- 전체 조회 -------------------
     @Transactional(readOnly = true)
     public List<CategoryResponse> findRootCategories() {
         return categoryRepository.findByParentIsNull().stream()
@@ -35,7 +35,6 @@ public class CategoryService {
                 .toList();
     }
 
-    // ------------------- 단일 조회 -------------------
     @Transactional(readOnly = true)
     public CategoryResponse getCategoryById(UUID id) {
         Category category =
@@ -46,7 +45,6 @@ public class CategoryService {
         return CategoryResponse.fromEntity(category);
     }
 
-    // ------------------- 트리 조회 -------------------
     @Transactional(readOnly = true)
     public List<CategoryResponse> findCategoryTree() {
         List<Category> roots = categoryRepository.findByParentIsNull();
@@ -55,7 +53,6 @@ public class CategoryService {
                 .collect(Collectors.toList());
     }
 
-    // ------------------- 생성 -------------------
     public CategoryResponse createCategory(CategoryCreateRequest request) {
         Category category;
 
@@ -76,18 +73,16 @@ public class CategoryService {
         return CategoryResponse.fromEntity(saved);
     }
 
-    // ------------------- 수정 -------------------
-    public CategoryResponse updateCategory(UUID id, String newName) {
+    public CategoryResponse updateCategory(UUID id, CategoryUpdateRequest request) {
         Category category =
                 categoryRepository
                         .findById(id)
                         .orElseThrow(
                                 () -> new CommonException(CategoryErrorCode.CATEGORY_NOT_FOUND));
-        category.updateName(newName);
+        category.updateName(request.name());
         return CategoryResponse.fromEntity(category);
     }
 
-    // ------------------- 삭제 -------------------
     public void deleteCategory(UUID id) {
         Category category =
                 categoryRepository

--- a/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
@@ -38,7 +38,6 @@ public class Category extends BaseEntity {
     @Column(name = "depth", nullable = false)
     private int depth;
 
-    // ------------------- 생성 메서드 -------------------
     public static Category createRootCategory(String name) {
         return Category.builder().name(name).depth(1).build();
     }
@@ -59,7 +58,6 @@ public class Category extends BaseEntity {
         this.children.add(child);
     }
 
-    // ------------------- 수정 메서드 -------------------
     public void updateName(String name) {
         this.name = name;
     }

--- a/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/entity/Category.java
@@ -1,5 +1,6 @@
 package com.irum.come2us.domain.category.domain.entity;
 
+import com.irum.come2us.global.domain.BaseEntity;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.CategoryErrorCode;
 import jakarta.persistence.*;
@@ -15,7 +16,7 @@ import org.hibernate.annotations.UuidGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class Category {
+public class Category extends BaseEntity {
 
     private static final int MAX_DEPTH = 3;
 

--- a/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/irum/come2us/domain/category/domain/repository/CategoryRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
-    List<Category> findByParentIsNull(); // 루트 카테고리 조회
+    List<Category> findByParentIsNull();
 
     @Query("SELECT c FROM Category c WHERE c.parent.categoryId = :parentId")
     List<Category> findChildrenByParentId(@Param("parentId") UUID parentId);

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.irum.come2us.domain.category.presentation.controller;
 import com.irum.come2us.domain.category.application.service.CategoryService;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryUpdateRequest;
+import com.irum.come2us.domain.category.presentation.dto.response.CategoryInfoResponse;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -18,7 +19,7 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping
-    public List<CategoryResponse> getAllCategories(@RequestParam(required = false) UUID parentId) {
+    public List<CategoryInfoResponse> getAllCategories(@RequestParam(required = false) UUID parentId) {
         if (parentId != null) {
             return categoryService.findByParentId(parentId);
         }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -19,7 +19,8 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping
-    public List<CategoryInfoResponse> getAllCategories(@RequestParam(required = false) UUID parentId) {
+    public List<CategoryInfoResponse> getAllCategories(
+            @RequestParam(required = false) UUID parentId) {
         if (parentId != null) {
             return categoryService.findByParentId(parentId);
         }

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -2,9 +2,10 @@ package com.irum.come2us.domain.category.presentation.controller;
 
 import com.irum.come2us.domain.category.application.service.CategoryService;
 import com.irum.come2us.domain.category.presentation.dto.request.CategoryCreateRequest;
+import com.irum.come2us.domain.category.presentation.dto.request.CategoryUpdateRequest;
 import com.irum.come2us.domain.category.presentation.dto.response.CategoryResponse;
+import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,7 +17,6 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    // ------------------- 전체 조회 -------------------
     @GetMapping
     public List<CategoryResponse> getAllCategories(@RequestParam(required = false) UUID parentId) {
         if (parentId != null) {
@@ -25,32 +25,27 @@ public class CategoryController {
         return categoryService.findRootCategories();
     }
 
-    // ------------------- 단일 조회 -------------------
     @GetMapping("/{id}")
     public CategoryResponse getCategoryById(@PathVariable UUID id) {
         return categoryService.getCategoryById(id);
     }
 
-    // ------------------- 트리 조회 -------------------
     @GetMapping("/tree")
     public List<CategoryResponse> getCategoryTree() {
         return categoryService.findCategoryTree();
     }
 
-    // ------------------- 생성 -------------------
     @PostMapping
-    public CategoryResponse createCategory(@RequestBody CategoryCreateRequest request) {
+    public CategoryResponse createCategory(@Valid @RequestBody CategoryCreateRequest request) {
         return categoryService.createCategory(request);
     }
 
-    // ------------------- 수정 -------------------
     @PatchMapping("/{id}")
     public CategoryResponse updateCategory(
-            @PathVariable UUID id, @RequestBody Map<String, String> request) {
-        return categoryService.updateCategory(id, request.get("name"));
+            @PathVariable UUID id, @Valid @RequestBody CategoryUpdateRequest request) {
+        return categoryService.updateCategory(id, request);
     }
 
-    // ------------------- 삭제 -------------------
     @DeleteMapping("/{id}")
     public void deleteCategory(@PathVariable UUID id) {
         categoryService.deleteCategory(id);

--- a/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/controller/CategoryController.java
@@ -18,8 +18,11 @@ public class CategoryController {
 
     // ------------------- 전체 조회 -------------------
     @GetMapping
-    public List<CategoryResponse> getAllCategories() {
-        return categoryService.findAllCategories();
+    public List<CategoryResponse> getAllCategories(@RequestParam(required = false) UUID parentId) {
+        if (parentId != null) {
+            return categoryService.findByParentId(parentId);
+        }
+        return categoryService.findRootCategories();
     }
 
     // ------------------- 단일 조회 -------------------

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryCreateRequest.java
@@ -1,6 +1,8 @@
 package com.irum.come2us.domain.category.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.UUID;
 
-public record CategoryCreateRequest(String name, UUID parentId // null이면 루트 카테고리
+public record CategoryCreateRequest(
+        @NotBlank(message = "카테고리명은 필수 입력값입니다.") String name, UUID parentId // null이면 루트 카테고리
         ) {}

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryUpdateRequest.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/request/CategoryUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.irum.come2us.domain.category.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CategoryUpdateRequest(@NotBlank(message = "카테고리명은 필수 입력값입니다.") String name) {}

--- a/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryResponse.java
+++ b/src/main/java/com/irum/come2us/domain/category/presentation/dto/response/CategoryResponse.java
@@ -11,7 +11,6 @@ public record CategoryResponse(
         UUID parentId,
         List<CategoryResponse> children // 트리 조회용
         ) {
-    // ------------------- 단일 조회용 -------------------
     public static CategoryResponse fromEntity(Category category) {
         return new CategoryResponse(
                 category.getCategoryId(),
@@ -21,7 +20,6 @@ public record CategoryResponse(
                 null);
     }
 
-    // ------------------- 트리 조회용 -------------------
     public static CategoryResponse fromEntityWithChildren(Category category) {
         return new CategoryResponse(
                 category.getCategoryId(),


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #202

## 📌 **작업 내용 및 특이사항**
기존 카테고리 조회는 "카테고리 전체 목록 조회", "카테고리 트리형 전체 조회" 뿐이라서 불필요하게 많은 데이터를 조회하는 문제점이 있어 리팩토링 진행하게 되었습니다. 다른 eCommerce의 카테고리 조회 형식을 참고하여 계층형 조회 구조로 변환했습니다.

변경 전: 1, 2, 3 depth 전부 조회
변경 후: 1 -> 2 -> 3 depth를 하나씩 펼치는 식으로 조회

### Controller
- `/categoris` API가 parentId 기반 조건으로 동작하도록 수정
  - `GET /categories` : 루트 카테고리 조회
  - `GET /categories?parentId={id}` : 특정 카테고리의 하위 카테고리 조회

### Service
- `findAllCategories()` 메서드 제거 및 메서드 분리
  - `findRootCategories()` : 루트 카테고리 조회
  - `findByParentId(UUID parentId)` : 특정 카테고리 하위 조회

### Repository
- `findChildrenByParentId(UUID parentId)` 쿼리 메서드 재사용
```java
@Query("SELECT c FROM Category c WHERE c.parent.categoryId = :parentId")
List<Category> findChildrenByParentId(@Param("parentId") UUID parentId);
```

📚 **참고사항**
- `/categories/tree`는 그대로 유지 (관리자용 전체 트리 조회) — `@BatchSize` 설정 기반으로 Lazy 로딩 시 효율적 작동 확인