### PR TITLE
[Fix] 트랜잭션-I/O 분리, 이미지 등록 로직 수정

### DIFF
--- a/src/main/java/com/irum/come2us/domain/product/application/service/FileStorageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/FileStorageService.java
@@ -1,6 +1,5 @@
 package com.irum.come2us.domain.product.application.service;
 
-import com.irum.come2us.global.constants.FileStorageConstants;
 import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductImageErrorCode;
 import java.io.IOException;
@@ -10,37 +9,30 @@ import java.nio.file.Paths;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
 public class FileStorageService {
 
-    /** 파일 저장 */
+    private static final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
+
+    /** 로컬 디렉토리에 파일 저장 */
     public String save(MultipartFile file) {
         try {
-            // 파일명 정화 (경로 탈출 방지)
             String originalName = file.getOriginalFilename();
-            if (originalName == null || originalName.isBlank()) {
-                throw new CommonException(ProductImageErrorCode.FILE_SAVE_FAILED);
+            if (originalName == null) {
+                throw new CommonException(ProductImageErrorCode.INVALID_FILE_FORMAT);
             }
 
-            String cleanFilename = StringUtils.cleanPath(originalName);
-            String uniqueName = UUID.randomUUID() + "_" + cleanFilename;
+            String uniqueName = UUID.randomUUID() + "_" + originalName;
+            Path path = Paths.get(UPLOAD_DIR, uniqueName);
 
-            // 디렉토리 생성
-            Path uploadPath = Paths.get(FileStorageConstants.UPLOAD_DIR);
-            if (!Files.exists(uploadPath)) {
-                Files.createDirectories(uploadPath);
-            }
+            Files.createDirectories(path.getParent());
+            file.transferTo(path.toFile());
 
-            // 안전하게 경로 연결
-            Path filePath = uploadPath.resolve(uniqueName).normalize();
-
-            file.transferTo(filePath.toFile());
-            log.info("파일 저장 완료: {}", filePath.toAbsolutePath());
-            return filePath.toAbsolutePath().toString(); // S3 시 URL로 대체
+            log.info("파일 저장 완료: {}", path.toAbsolutePath());
+            return path.toString();
         } catch (IOException e) {
             log.error("파일 저장 실패", e);
             throw new CommonException(ProductImageErrorCode.FILE_SAVE_FAILED);
@@ -51,11 +43,11 @@ public class FileStorageService {
     public void delete(String filePath) {
         try {
             if (filePath == null || filePath.isBlank()) return;
-            Path path = Paths.get(filePath).normalize();
+            Path path = Paths.get(filePath);
             Files.deleteIfExists(path);
             log.info("파일 삭제 완료: {}", path.toAbsolutePath());
         } catch (IOException e) {
-            log.warn("파일 삭제 실패: {}", filePath);
+            log.warn("파일 삭제 실패: {}", filePath, e);
         }
     }
 }

--- a/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
+++ b/src/main/java/com/irum/come2us/domain/product/application/service/ProductImageService.java
@@ -1,6 +1,5 @@
 package com.irum.come2us.domain.product.application.service;
 
-import com.irum.come2us.domain.member.domain.entity.Member;
 import com.irum.come2us.domain.product.domain.entity.Product;
 import com.irum.come2us.domain.product.domain.entity.ProductImage;
 import com.irum.come2us.domain.product.domain.repository.ProductImageRepository;
@@ -11,11 +10,11 @@ import com.irum.come2us.global.presentation.advice.exception.CommonException;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductErrorCode;
 import com.irum.come2us.global.presentation.advice.exception.errorcode.ProductImageErrorCode;
 import com.irum.come2us.global.util.MemberUtil;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,43 +35,38 @@ public class ProductImageService {
             Pattern.compile(FileStorageConstants.IMAGE_EXTENSION_REGEX);
 
     /** 상품 이미지 업로드 */
-    public void uploadProductImages(UUID productId, List<MultipartFile> files, Boolean isDefault) {
-        // 파일 저장
-        List<String> storedUrls =
-                files.stream()
-                        .map(
-                                file -> {
-                                    validateFile(file);
-                                    return fileStorageService.save(file);
-                                })
-                        .collect(Collectors.toList());
+    public void uploadProductImages(UUID productId, List<MultipartFile> files) {
+        List<String> storedUrls = new ArrayList<>();
 
-        // DB 저장
-        saveProductImages(productId, storedUrls, isDefault);
+        try {
+            for (MultipartFile file : files) {
+                validateFile(file);
+                storedUrls.add(fileStorageService.save(file));
+            }
+
+            saveProductImages(productId, storedUrls);
+        } catch (Exception e) {
+            storedUrls.forEach(fileStorageService::delete);
+            log.warn("파일 저장 중 예외 발생, 업로드된 파일 {}건 삭제 완료", storedUrls.size());
+            throw e;
+        }
     }
 
     @Transactional
-    protected void saveProductImages(UUID productId, List<String> storedUrls, Boolean isDefault) {
-        Member member = memberUtil.getCurrentMember();
+    protected void saveProductImages(UUID productId, List<String> storedUrls) {
         Product product = findValidProduct(productId);
         memberUtil.assertMemberResourceAccess(product.getStore().getMember());
 
-        if (Boolean.TRUE.equals(isDefault)) {
-            boolean alreadyHasDefault =
-                    productImageRepository.findByProductId(productId).stream()
-                            .anyMatch(ProductImage::isDefault);
-            if (alreadyHasDefault) {
-                throw new CommonException(ProductImageErrorCode.DUPLICATE_DEFAULT_IMAGE);
-            }
-        }
+        boolean hasExistingImages = productImageRepository.existsByProductId(productId);
 
-        for (String storedUrl : storedUrls) {
-            ProductImage productImage = ProductImage.create(product, storedUrl, isDefault);
+        for (int i = 0; i < storedUrls.size(); i++) {
+            boolean isDefault = !hasExistingImages && i == 0;
+            ProductImage productImage = ProductImage.create(product, storedUrls.get(i), isDefault);
             productImageRepository.save(productImage);
             log.info(
                     "상품 이미지 등록 완료: productId={}, storedUrl={}, isDefault={}",
                     productId,
-                    storedUrl,
+                    storedUrls.get(i),
                     isDefault);
         }
     }
@@ -114,6 +108,7 @@ public class ProductImageService {
         boolean wasDefault = image.isDefault();
 
         fileStorageService.delete(image.getImageUrl());
+        image.unmarkAsDefault();
         productImageRepository.delete(image);
         productImageRepository.flush();
 

--- a/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductImage.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/entity/ProductImage.java
@@ -13,9 +13,7 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
-@Table(
-        name = "p_product_image",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"product_id", "is_default"})})
+@Table(name = "p_product_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE p_product_image SET deleted_at = NOW() WHERE product_image_id = ?")
 @Where(clause = "deleted_at IS NULL")

--- a/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductImageRepository.java
+++ b/src/main/java/com/irum/come2us/domain/product/domain/repository/ProductImageRepository.java
@@ -18,4 +18,6 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, UUID
 
     /** 해당 상품의 대표 이미지 존재 여부 확인 */
     boolean existsByProductIdAndIsDefaultTrue(UUID productId);
+
+    boolean existsByProductId(UUID productId);
 }

--- a/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductImageController.java
+++ b/src/main/java/com/irum/come2us/domain/product/presentation/controller/ProductImageController.java
@@ -20,15 +20,9 @@ public class ProductImageController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public void uploadProductImages(
-            @PathVariable UUID productId,
-            @RequestPart("files") List<MultipartFile> files,
-            @RequestPart("isDefault") Boolean isDefault) {
-        log.info(
-                "상품 이미지 업로드 요청: productId={}, fileCount={}, isDefault={}",
-                productId,
-                files.size(),
-                isDefault);
-        productImageService.uploadProductImages(productId, files, isDefault);
+            @PathVariable UUID productId, @RequestPart("files") List<MultipartFile> files) {
+        log.info("상품 이미지 업로드 요청: productId={}, fileCount={}", productId, files.size());
+        productImageService.uploadProductImages(productId, files);
     }
 
     @PatchMapping("/{imageId}/default")


### PR DESCRIPTION
📌 **작업 내용 및 특이사항**
- 트랜잭션 - I/O 분리
  - DB 트랜잭션이 이뤄져야 하는 로직과 I/O 작업에 대한 로직 분리
- 이미지 등록 로직 수정
  - 이미지 업로드 시 `isDefault`를 받지 않음
  - 이미지 생성 시 모든 이미지의 `isDefault`는 `false`를 기본으로 함
  - 해당 상품의 이미지가 없는 경우에는 첫 장의 이미지를 `isDefault=true`로 하여 저장
- 스토리지-DB 불일치 해결
  - 스토리지-DB에 이미지 저장 흐름이 완전하지 않아 스토리지에는 저장되었지만 DB row에는 저장되지 않는 불일치 문제 발생
  - try-catch 문을 통해 DB 트랜잭션이 이뤄지지 않을 경우 이미지 저장 롤백 구현
- Entity `uniqueConstraints` 제거
  - 원래 의도는 true 하나만 존재하게 하려고 제약을 걸어두었지만,
  - 의도와 다르게 false까지 중복을 허용하지 못하게 하고 있어 제거


📚 **참고사항**
- 임시로 파일 저장에 대한 주소는 절대경로 사용하여 구현했습니다.