### PR TITLE
[Test] ProductImage API Test

### DIFF
--- a/src/docs/asciidoc/_product_image.adoc
+++ b/src/docs/asciidoc/_product_image.adoc
@@ -1,0 +1,46 @@
+== 상품 이미지 (Product Image) API
+
+=== 1. 상품 이미지 업로드
+`POST /products/{productId}/images`
+
+요청 경로 파라미터:
+include::{snippets}/product-image-upload/path-parameters.adoc[]
+
+요청 본문 (Multipart):
+include::{snippets}/product-image-upload/request-parts.adoc[]
+
+응답:
+include::{snippets}/product-image-upload/http-response.adoc[]
+
+
+=== 2. 상품 이미지 조회
+`GET /products/{productId}/images`
+
+요청 경로 파라미터:
+include::{snippets}/product-image-list-get/path-parameters.adoc[]
+
+응답 본문:
+include::{snippets}/product-image-list-get/response-fields.adoc[]
+
+응답:
+include::{snippets}/product-image-list-get/http-response.adoc[]
+
+
+=== 3. 대표 이미지 변경
+`PATCH /products/{productId}/images/{imageId}/default`
+
+요청 경로 파라미터:
+include::{snippets}/product-image-change-default/path-parameters.adoc[]
+
+응답:
+include::{snippets}/product-image-change-default/http-response.adoc[]
+
+
+=== 4. 상품 이미지 삭제
+`DELETE /products/{productId}/images/{imageId}`
+
+요청 경로 파라미터:
+include::{snippets}/product-image-delete/path-parameters.adoc[]
+
+응답:
+include::{snippets}/product-image-delete/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,4 +15,5 @@ include::_discount.adoc[]
 
 include::_deliverypolicy.adoc[]
 // include::_product.adoc[]
+include::_product_image.adoc[]
 

--- a/src/test/java/com/irum/come2us/domain/product/ProductImageControllerTest.java
+++ b/src/test/java/com/irum/come2us/domain/product/ProductImageControllerTest.java
@@ -1,0 +1,150 @@
+package com.irum.come2us.domain.product;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.irum.come2us.domain.product.application.service.ProductImageService;
+import com.irum.come2us.domain.product.presentation.controller.ProductImageController;
+import com.irum.come2us.domain.product.presentation.dto.response.ProductImageResponse;
+import com.irum.come2us.global.config.SecurityTestConfig;
+import com.irum.come2us.global.config.TestConfig;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProductImageController.class)
+@AutoConfigureRestDocs
+@Import({SecurityTestConfig.class, TestConfig.class})
+public class ProductImageControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ProductImageService productImageService;
+    @Autowired private ObjectMapper objectMapper;
+
+    private final UUID mockProductId = UUID.randomUUID();
+    private final UUID mockImageId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("상품 이미지 업로드 API (사장님 권한)")
+    void uploadProductImagesApiTest() throws Exception {
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "images", "test.jpg", MediaType.IMAGE_JPEG_VALUE, "dummy".getBytes());
+
+        doNothing().when(productImageService).uploadProductImages(eq(mockProductId), any());
+
+        mockMvc.perform(
+                        multipart("/products/{productId}/images", mockProductId)
+                                .file(file)
+                                .with(csrf())
+                                .with(user("100").roles("OWNER")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(HttpStatus.CREATED.value()))
+                .andDo(
+                        document(
+                                "product-image-upload",
+                                pathParameters(parameterWithName("productId").description("상품 ID")),
+                                requestParts(
+                                        partWithName("images").description("업로드할 상품 이미지 파일들"))));
+    }
+
+    @Test
+    @DisplayName("대표 이미지 변경 API (사장님 권한)")
+    void changeDefaultImageApiTest() throws Exception {
+        doNothing()
+                .when(productImageService)
+                .changeDefaultImage(eq(mockProductId), eq(mockImageId));
+
+        mockMvc.perform(
+                        patch(
+                                        "/products/{productId}/images/{imageId}/default",
+                                        mockProductId,
+                                        mockImageId)
+                                .with(csrf())
+                                .with(user("100").roles("OWNER")))
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()))
+                .andDo(
+                        document(
+                                "product-image-change-default",
+                                pathParameters(
+                                        parameterWithName("productId").description("상품 ID"),
+                                        parameterWithName("imageId")
+                                                .description("대표로 변경할 이미지 ID"))));
+    }
+
+    @Test
+    @DisplayName("상품 이미지 삭제 API (사장님 권한)")
+    void deleteProductImageApiTest() throws Exception {
+        doNothing()
+                .when(productImageService)
+                .deleteProductImage(eq(mockProductId), eq(mockImageId));
+
+        mockMvc.perform(
+                        delete("/products/{productId}/images/{imageId}", mockProductId, mockImageId)
+                                .with(csrf())
+                                .with(user("100").roles("OWNER")))
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.status").value(HttpStatus.NO_CONTENT.value()))
+                .andDo(
+                        document(
+                                "product-image-delete",
+                                pathParameters(
+                                        parameterWithName("productId").description("상품 ID"),
+                                        parameterWithName("imageId").description("삭제할 이미지 ID"))));
+    }
+
+    @Test
+    @DisplayName("상품 이미지 목록 조회 API")
+    void getProductImagesApiTest() throws Exception {
+        List<ProductImageResponse> responseList =
+                List.of(
+                        new ProductImageResponse(
+                                mockImageId, "https://cdn.example.com/img.jpg", true));
+
+        when(productImageService.getProductImages(eq(mockProductId))).thenReturn(responseList);
+
+        mockMvc.perform(
+                        get("/products/{productId}/images", mockProductId)
+                                .with(csrf())
+                                .with(user("1").roles("CUSTOMER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].id").value(mockImageId.toString()))
+                .andExpect(jsonPath("$.data[0].isDefault").value(true))
+                .andDo(
+                        document(
+                                "product-image-list-get",
+                                pathParameters(parameterWithName("productId").description("상품 ID")),
+                                responseFields(
+                                        fieldWithPath("success").description("요청 성공 여부"),
+                                        fieldWithPath("status").description("HTTP 상태 코드"),
+                                        fieldWithPath("data[].id").description("상품 이미지 식별 ID"),
+                                        fieldWithPath("data[].imageUrl").description("이미지 URL"),
+                                        fieldWithPath("data[].isDefault").description("대표 이미지 여부"),
+                                        fieldWithPath("timestamp").description("응답 시간"))));
+    }
+}

--- a/src/test/java/com/irum/come2us/global/config/TestConfig.java
+++ b/src/test/java/com/irum/come2us/global/config/TestConfig.java
@@ -6,6 +6,7 @@ import com.irum.come2us.domain.deliveryaddress.application.service.DeliveryAddre
 import com.irum.come2us.domain.discount.application.service.DiscountService;
 import com.irum.come2us.domain.member.application.service.ManagerService;
 import com.irum.come2us.domain.member.application.service.MemberService;
+import com.irum.come2us.domain.product.application.service.ProductImageService;
 import com.irum.come2us.domain.refund.application.service.RefundService;
 import com.irum.come2us.global.util.CookieUtil;
 import org.mockito.Mockito;
@@ -52,5 +53,10 @@ public class TestConfig {
     @Bean
     public DiscountService discountService() {
         return Mockito.mock(DiscountService.class);
+    }
+
+    @Bean
+    public ProductImageService productImageService() {
+        return Mockito.mock(ProductImageService.class);
     }
 }


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #201 

📌 **작업 내용 및 특이사항**

### ProductImage(상품 이미지) API 구현
- 상품 이미지 등록 API (`POST /product-images`)
- 상품 이미지 조회 API (`GET /product-images/products/{productId}`)
- 상품 이미지 수정 API (`PATCH /product-images/{imageId}`)
- 상품 이미지 삭제 API (`DELETE /product-images/{imageId}`)


단일 상품 다중 이미지 업로드 구현 (대표 이미지 중복 방지 로직 포함)
파일명 정규화 및 UUID 기반 저장 (FileStorageService 적용)
FileProperties 추가 및 PropertiesConfig에 반영

📚 **참고사항**
- 로컬 파일 시스템 저장 기준으로 구현 (추후 S3 전환 고려)
- 향후 Product 삭제 시 연관 이미지 일괄 삭제 로직 추가 예정
